### PR TITLE
Fix constant naming in Pin Tester

### DIFF
--- a/gateware/pin-tester/source/alchitry_top.luc
+++ b/gateware/pin-tester/source/alchitry_top.luc
@@ -72,11 +72,11 @@ module alchitry_top (
 
                 // using 8 doesn't allow to have a lot of granularity
                 // when sampling only pin0 of ffc connector
-                const out_bank_multiplier = 2
+                const OUT_BANK_MULTIPLIER = 2
 
-                led = counter.q[(bank.q * out_bank_multiplier)+:8]
-                saleae = counter.q[(bank.q * out_bank_multiplier)+:8]
-                ffc_data[0+:8] = counter.q[(bank.q * out_bank_multiplier)+:8]
+                led = counter.q[(bank.q * OUT_BANK_MULTIPLIER)+:8]
+                saleae = counter.q[(bank.q * OUT_BANK_MULTIPLIER)+:8]
+                ffc_data[0+:8] = counter.q[(bank.q * OUT_BANK_MULTIPLIER)+:8]
 
                 if (rx.new_data) {
                     if (rx.data >= "0" && rx.data <= "9") {

--- a/gateware/pin-tester/source/alchitry_top.luc
+++ b/gateware/pin-tester/source/alchitry_top.luc
@@ -12,6 +12,10 @@ module alchitry_top (
     sig rst
     enum States {RECEIVE, SEND}
 
+    // using 8 doesn't allow to have a lot of granularity
+    // when sampling only pin0 of ffc connector
+    const OUT_BANK_MULTIPLIER = 2
+
     .clk(clk) {
         reset_conditioner reset_cond
 
@@ -69,10 +73,6 @@ module alchitry_top (
 
             States.SEND:
                 counter.d = counter.q + 1
-
-                // using 8 doesn't allow to have a lot of granularity
-                // when sampling only pin0 of ffc connector
-                const OUT_BANK_MULTIPLIER = 2
 
                 led = counter.q[(bank.q * OUT_BANK_MULTIPLIER)+:8]
                 saleae = counter.q[(bank.q * OUT_BANK_MULTIPLIER)+:8]


### PR DESCRIPTION
## Summary
- rename `out_bank_multiplier` constant to `OUT_BANK_MULTIPLIER` in pin tester gateware

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e0b14429c8331a9ac0e8f549eaea6