### PR TITLE
Keep gateware stub sources

### DIFF
--- a/gateware/.gitignore
+++ b/gateware/.gitignore
@@ -38,7 +38,6 @@ wt/
 *.xml
 *_sim_netlist.v
 *_sim_netlist.vhdl
-*_stub.v
 *_stub.vhdl
 *_bmstub.v
 *_clk_wiz.v


### PR DESCRIPTION
## Summary
- keep generated `_stub.v` sources under gateware

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e10dbfd1c833192a8cbdfe1a0a6eb