### PR TITLE
Fix pytest import conflicts

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -1,1 +1,0 @@
-# RetroBus Explorer Python package


### PR DESCRIPTION
## Summary
- remove `py/__init__.py` to avoid name collision with pytest's `py` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bce07c2948331b51bc8759ab77a9a