### PR TITLE
Use integer math for key matrix row decoding

### DIFF
--- a/py/z80bus/key_matrix.py
+++ b/py/z80bus/key_matrix.py
@@ -1,4 +1,3 @@
-import math
 from dataclasses import dataclass
 
 from z80bus.bus_parser import Event, IOPort
@@ -85,8 +84,7 @@ class KeyMatrixInterpreter:
                 strobe = (self.strobe_hi << 8) | self.strobe_lo
                 if event.val == 0 or strobe == 0:
                     return
-                # row is the power of 2 of the strobe value, only has 1 bit set
-                row = int(math.log2(strobe))
+                row = self._row_from_strobe(strobe)
                 for i in range(8):
                     if event.val & (1 << i):
                         self.cur.append(PressedKey(row=row, col=i))
@@ -95,3 +93,8 @@ class KeyMatrixInterpreter:
                 self.last_full_state = self.cur.copy()
                 self.last_shift_state = event.val
                 self.cur = []
+
+    @staticmethod
+    def _row_from_strobe(strobe: int) -> int:
+        """Return the index of the active row for the given strobe mask."""
+        return strobe.bit_length() - 1

--- a/py/z80bus/test_key_matrix.py
+++ b/py/z80bus/test_key_matrix.py
@@ -47,6 +47,12 @@ def test_key_matrix():
     ).cur == [PressedKey(row=1, col=1)]
 
     assert eval(
+        out_port(0x01, IOPort.SET_KEY_STROBE_HI)
+        + out_port(0x00, IOPort.SET_KEY_STROBE_LO)
+        + in_port(0x01, IOPort.KEY_INPUT)
+    ).cur == [PressedKey(row=8, col=0)]
+
+    assert eval(
         out_port(0x02, IOPort.SET_KEY_STROBE_LO)
         + in_port(0x02, IOPort.KEY_INPUT)
         + in_port(0x00, IOPort.SHIFT_KEY_INPUT)


### PR DESCRIPTION
## Summary
- decode key matrix strobe rows using integer bit-length logic instead of floating point log2
- add a regression test covering high-order strobe rows to ensure decoding stays correct

## Testing
- pytest py/z80bus/test_key_matrix.py

------
https://chatgpt.com/codex/tasks/task_e_68cc84b44ce88331a9f8b8683bda5d87