### PR TITLE
Initialize ParseRenderManager during construction

### DIFF
--- a/py/z80bus/server.py
+++ b/py/z80bus/server.py
@@ -29,6 +29,7 @@ class ParseRenderManager:
             with cls._instance_lock:
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
+                    cls._instance.reset()
         return cls._instance
 
     def reset(self):

--- a/py/z80bus/test_server.py
+++ b/py/z80bus/test_server.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("uvicorn")
+
+from z80bus.server import ParseRenderManager
+
+
+def test_parse_render_manager_initializes_on_construction():
+    manager = ParseRenderManager()
+
+    # The manager should be ready to use without requiring an explicit reset.
+    assert manager.get_accumulated_events() == []
+
+    image_bytes = manager.get_lcd_image_bytes()
+    assert isinstance(image_bytes, bytes)
+    assert image_bytes  # image data should not be empty
+
+    stats = manager.stats()
+    assert stats["num_errors"] == 0
+
+    # Leave the singleton in a clean state for other tests.
+    manager.reset()


### PR DESCRIPTION
## Summary
- call `reset()` the first time `ParseRenderManager` is constructed so its queues and parser are ready immediately
- add a regression test that exercises the singleton without an explicit reset and skips when FastAPI/Uvicorn are unavailable

## Testing
- `cd py && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cfc2066d18833185f1fafd78b0c3d7