### PR TITLE
Improve KeyMatrixInterpreter equality checks

### DIFF
--- a/py/z80bus/key_matrix.py
+++ b/py/z80bus/key_matrix.py
@@ -44,15 +44,15 @@ class KeyMatrixState:
 class KeyMatrixInterpreter:
     def __init__(self):
         # strobing rows
-        self.strobe_hi = 0
-        self.strobe_lo = 0
-        self.cur = []
-        self.last_full_state = []
-        self.last_shift_state = False
+        self.strobe_hi: int = 0
+        self.strobe_lo: int = 0
+        self.cur: list[PressedKey] = []
+        self.last_full_state: list[PressedKey] = []
+        self.last_shift_state: bool = False
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, KeyMatrixInterpreter):
-            return NotImplemented
+            return False
         return (
             self.strobe_hi == other.strobe_hi
             and self.strobe_lo == other.strobe_lo
@@ -61,7 +61,7 @@ class KeyMatrixInterpreter:
             and self.last_shift_state == other.last_shift_state
         )
 
-    def pressed_keys(self):
+    def pressed_keys(self) -> list[PressedKey]:
         if self.last_shift_state:
             return self.last_full_state + [PressedKey(row=0xff, col=0xff)]
         return self.last_full_state
@@ -94,7 +94,7 @@ class KeyMatrixInterpreter:
             case IOPort.SHIFT_KEY_INPUT:
                 # key matrix scanning ends with SHIFT_KEY_INPUT query
                 self.last_full_state = self.cur.copy()
-                self.last_shift_state = event.val
+                self.last_shift_state = bool(event.val)
                 self.cur = []
 
     @staticmethod

--- a/py/z80bus/key_matrix.py
+++ b/py/z80bus/key_matrix.py
@@ -50,12 +50,15 @@ class KeyMatrixInterpreter:
         self.last_full_state = []
         self.last_shift_state = False
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, KeyMatrixInterpreter):
+            return NotImplemented
         return (
             self.strobe_hi == other.strobe_hi
             and self.strobe_lo == other.strobe_lo
             and self.cur == other.cur
             and self.last_full_state == other.last_full_state
+            and self.last_shift_state == other.last_shift_state
         )
 
     def pressed_keys(self):

--- a/py/z80bus/test_key_matrix.py
+++ b/py/z80bus/test_key_matrix.py
@@ -62,3 +62,24 @@ def test_key_matrix():
         + in_port(0x02, IOPort.KEY_INPUT)
         + in_port(0x00, IOPort.SHIFT_KEY_INPUT)
     )) == "S"
+
+
+def test_key_matrix_equality_compares_shift_state():
+    base_state = eval(
+        out_port(0x02, IOPort.SET_KEY_STROBE_LO)
+        + in_port(0x02, IOPort.KEY_INPUT)
+        + in_port(0x00, IOPort.SHIFT_KEY_INPUT)
+    )
+    shift_state = eval(
+        out_port(0x02, IOPort.SET_KEY_STROBE_LO)
+        + in_port(0x02, IOPort.KEY_INPUT)
+        + in_port(0x01, IOPort.SHIFT_KEY_INPUT)
+    )
+
+    assert base_state != shift_state
+
+
+def test_key_matrix_equality_handles_other_types():
+    interpreter = KeyMatrixInterpreter()
+    assert interpreter == KeyMatrixInterpreter()
+    assert interpreter != object()


### PR DESCRIPTION
## Summary
- ensure `KeyMatrixInterpreter.__eq__` validates operand type and includes the shift state
- add regression tests covering equality across shift states and mismatched types

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfc2066d18833185f1fafd78b0c3d7