### PR TITLE
Use set for duplicate pin detection in tests

### DIFF
--- a/py/test_jitx_to_fpga_mapping.py
+++ b/py/test_jitx_to_fpga_mapping.py
@@ -92,12 +92,12 @@ class TestPinMappings:
         """Ensure no physical pins are used twice in same board"""
         for config in BOARD_CONFIGS:
             content = config.generator()
-            pins = []
+            pins: set[str] = set()
             for line in content.split("\n"):
                 if line.strip().startswith("pin"):
                     pin = line.split()[-1]
                     assert pin not in pins, f"Duplicate pin {pin} in {config.name} mapping"
-                    pins.append(pin)
+                    pins.add(pin)
 
 
 


### PR DESCRIPTION
## Summary
- replace the list used for duplicate pin detection in the pin mapping tests with a set to avoid quadratic lookups

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e0528a28548331bb4ecf54581f7418