### PR TITLE
Optimize buffer handling in streaming parsers

### DIFF
--- a/py/z80bus/bus_parser.py
+++ b/py/z80bus/bus_parser.py
@@ -444,17 +444,17 @@ def parse_data_thread(
     status_num_input_data = 0
     status_num_empty_queue = 0
 
-    buf = b""
+    buf = bytearray()
     while True:
         data = input_queue.get()
         if data is None:
             break
 
         status_num_input_data += 1
-        buf += data
-        buf = parser.parse(buf)
+        buf.extend(data)
+        buf = bytearray(parser.parse(buf))
 
-    buf = parser.parse(buf)
+    buf = bytearray(parser.parse(buf))
     parser.flush()
 
     # all_events_output.put(parser.all_events)

--- a/py/z80bus/server.py
+++ b/py/z80bus/server.py
@@ -40,7 +40,11 @@ class ParseRenderManager:
         self.errors_queue = queue.SimpleQueue()
         self.parser = PipelineBusParser(self.errors_queue, self.out_ports_queue)
 
-        self.buf = b""
+        # ``PipelineBusParser`` expects a bytes-like object and returns the
+        # unconsumed remainder of the buffer.  ``bytearray`` lets us extend the
+        # buffer without repeatedly creating new temporary ``bytes`` objects
+        # for every chunk of incoming data.
+        self.buf = bytearray()
         self.status_num_out_ports = 0
         self.status_num_lcd_commands = 0
         self.status_num_errors = 0
@@ -62,14 +66,14 @@ class ParseRenderManager:
             self.lcd.eval(c)
 
     def process_raw_data(self, data: bytes) -> None:
-        self.buf += data
-        self.buf = self.parser.parse(self.buf)
+        self.buf.extend(data)
+        self.buf = bytearray(self.parser.parse(self.buf))
         self.process_queues()
 
     def stats(self):
         out_ports_queue_size_before = self.out_ports_queue.qsize()
 
-        self.buf = self.parser.parse(self.buf)
+        self.buf = bytearray(self.parser.parse(self.buf))
         self.parser.flush()
         self.process_queues()
 


### PR DESCRIPTION
## Summary
- store streaming parser buffers in bytearray objects to avoid repeated bytes reallocations
- reuse the optimized buffer handling in the background parsing thread

## Testing
- pytest py/z80bus -q

------
https://chatgpt.com/codex/tasks/task_e_68e1a5176704833186189c97a23e9ddd