### PR TITLE
Fix import path handling in server module

### DIFF
--- a/py/z80bus/server.py
+++ b/py/z80bus/server.py
@@ -1,23 +1,18 @@
 # pypy server.py -m z80bus
 
 import io
-import os
 import queue
-import sys
 import threading
 from typing import Any
-
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse, StreamingResponse
 from PIL import ImageFont
 
-from z80bus.bus_parser import PipelineBusParser
-from z80bus.key_matrix import KeyMatrixInterpreter
-from z80bus.sed1560 import SED1560Interpreter, SED1560Parser
+from .bus_parser import PipelineBusParser
+from .key_matrix import KeyMatrixInterpreter
+from .sed1560 import SED1560Interpreter, SED1560Parser
 
 
 class ParseRenderManager:


### PR DESCRIPTION
## Summary
- replace runtime sys.path manipulation in `z80bus.server` with package-relative imports to avoid side effects

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1a5176704833186189c97a23e9ddd