### PR TITLE
Simplify deque-to-list conversion in pc-e500 UART helper

### DIFF
--- a/gateware/reference/spade-projects/sharp-pc-e500-card-spade/scripts/pc_e500_experiment_common.py
+++ b/gateware/reference/spade-projects/sharp-pc-e500-card-spade/scripts/pc_e500_experiment_common.py
@@ -407,7 +407,8 @@ class ExperimentUART:
     def lines_since(self, index: int) -> list[UARTLine]:
         with self._cv:
             start = max(index - self._line_start, 0)
-            return list(list(self._lines)[start:])
+            lines = list(self._lines)
+            return lines[start:]
 
     def last_lines(self, limit: int = 20) -> list[str]:
         with self._cv:


### PR DESCRIPTION
### Motivation
- Remove a redundant nested `list(...)` conversion in `ExperimentUART.lines_since` to reduce overhead and improve clarity in the UART monitoring helper.

### Description
- Replace `return list(list(self._lines)[start:])` with a single conversion and slice (`lines = list(self._lines); return lines[start:]`) in `gateware/reference/spade-projects/sharp-pc-e500-card-spade/scripts/pc_e500_experiment_common.py`.

### Testing
- Ran `python -m py_compile gateware/reference/spade-projects/sharp-pc-e500-card-spade/scripts/pc_e500_experiment_common.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5dd3a61348331aef015d5dffb48ba)