### PR TITLE
Refactor subprocess error handling in pc-e500-card-asm.py

### DIFF
--- a/gateware/reference/spade-projects/sharp-pc-e500-card-spade/scripts/pc-e500-card-asm.py
+++ b/gateware/reference/spade-projects/sharp-pc-e500-card-spade/scripts/pc-e500-card-asm.py
@@ -169,15 +169,12 @@ def build_subprocess_env() -> dict[str, str]:
     return env
 
 
-def assemble_segments(source_path: Path, assembler_dir: Path) -> list[tuple[int, bytes]]:
-    if shutil.which("uv") is None:
-        raise SystemExit("uv was not found in PATH")
-
+def run_checked(command: list[str], *, cwd: Path | None = None, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
     completed = subprocess.run(
-        ["uv", "run", "python", "-c", ASSEMBLER_SNIPPET, str(source_path)],
-        cwd=assembler_dir,
+        command,
+        cwd=cwd,
         env=build_subprocess_env(),
-        capture_output=True,
+        capture_output=capture_output,
         text=True,
     )
     if completed.returncode != 0:
@@ -185,7 +182,19 @@ def assemble_segments(source_path: Path, assembler_dir: Path) -> list[tuple[int,
             sys.stdout.write(completed.stdout)
         if completed.stderr:
             sys.stderr.write(completed.stderr)
-        raise SystemExit("assembly failed")
+        raise SystemExit(completed.returncode)
+    return completed
+
+
+def assemble_segments(source_path: Path, assembler_dir: Path) -> list[tuple[int, bytes]]:
+    if shutil.which("uv") is None:
+        raise SystemExit("uv was not found in PATH")
+
+    completed = run_checked(
+        ["uv", "run", "python", "-c", ASSEMBLER_SNIPPET, str(source_path)],
+        cwd=assembler_dir,
+        capture_output=True,
+    )
 
     try:
         payload = json.loads(completed.stdout)
@@ -253,9 +262,7 @@ def run_au1_subcommand(
         command.extend(["--port", common_args.port])
     command.extend(subcommand)
 
-    completed = subprocess.run(command, env=build_subprocess_env(), text=True)
-    if completed.returncode != 0:
-        raise SystemExit(completed.returncode)
+    run_checked(command)
 
 
 def main() -> int:


### PR DESCRIPTION
### Motivation
- The script duplicated `subprocess.run(...)` usage and manual error/IO plumbing in multiple places, increasing maintenance burden and risk of inconsistent behavior.
- Centralize subprocess environment setup and non-zero exit handling to make failure semantics uniform and reduce code duplication.

### Description
- Add a `run_checked(command: list[str], *, cwd: Path | None = None, capture_output: bool = False) -> subprocess.CompletedProcess[str]` helper that runs subprocesses with `build_subprocess_env()`, streams `stdout`/`stderr` on failures, and raises `SystemExit` for non-zero return codes.
- Replace the inline assembler invocation in `assemble_segments` to call `run_checked(...)` and use its `stdout` for JSON parsing while preserving `capture_output=True` for that call.
- Replace the Au1 helper invocation in `run_au1_subcommand` to call `run_checked(...)` so both subprocess paths share the same environment and error handling.
- No behavior changes to success paths; failures now consistently propagate the subprocess return code via `SystemExit` and print subprocess output when present.

### Testing
- Ran `python -m py_compile gateware/reference/spade-projects/sharp-pc-e500-card-spade/scripts/pc-e500-card-asm.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7621220d48331b0d5af64c3ddb7c2)