### PR TITLE
Make strip_comments quote-aware and preserve newlines

### DIFF
--- a/gateware/reference/spade-projects/tools/test_text_filters.py
+++ b/gateware/reference/spade-projects/tools/test_text_filters.py
@@ -19,12 +19,24 @@ entity main(
 
         self.assertEqual(
             strip_comments(source),
+            "entity main(\n    clk: in bool, \n    \n\n    led: out bool,\n)\n\n",
+        )
+
+    def test_preserves_double_slash_inside_quotes(self) -> None:
+        source = """\
+entity main {
+    const url = \"https://example.com\"; // remove me
+    const slash = '// keep this literal';
+}
+"""
+
+        self.assertEqual(
+            strip_comments(source),
             """\
-entity main(
-    clk: in bool, 
-    
-    led: out bool,
-)
+entity main {
+    const url = \"https://example.com\"; 
+    const slash = '// keep this literal';
+}
 """,
         )
 

--- a/gateware/reference/spade-projects/tools/text_filters.py
+++ b/gateware/reference/spade-projects/tools/text_filters.py
@@ -1,11 +1,92 @@
 from __future__ import annotations
 
-import re
+
+def _strip_line_comment(line: str) -> str:
+    in_double_quote = False
+    in_single_quote = False
+    escaped = False
+
+    for idx, ch in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if ch == "\\":
+            escaped = True
+            continue
+
+        if ch == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            continue
+        if ch == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            continue
+
+        if ch == "/" and not in_double_quote and not in_single_quote:
+            if idx + 1 < len(line) and line[idx + 1] == "/":
+                return line[:idx]
+
+    return line
 
 
 def strip_comments(text: str) -> str:
-    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    out_chars: list[str] = []
+    i = 0
+    in_block_comment = False
+    in_double_quote = False
+    in_single_quote = False
+    escaped = False
+
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+                continue
+            if ch == "\n":
+                out_chars.append("\n")
+            i += 1
+            continue
+
+        if escaped:
+            out_chars.append(ch)
+            escaped = False
+            i += 1
+            continue
+
+        if ch == "\\":
+            out_chars.append(ch)
+            escaped = True
+            i += 1
+            continue
+
+        if ch == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            out_chars.append(ch)
+            i += 1
+            continue
+
+        if ch == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            out_chars.append(ch)
+            i += 1
+            continue
+
+        if not in_double_quote and not in_single_quote and ch == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+            continue
+
+        out_chars.append(ch)
+        i += 1
+
+    stripped_text = "".join(out_chars)
     lines: list[str] = []
-    for line in text.splitlines():
-        lines.append(line.split("//", 1)[0])
-    return "\n".join(lines)
+    for line in stripped_text.splitlines():
+        lines.append(_strip_line_comment(line))
+    result = "\n".join(lines)
+    if stripped_text.endswith("\n"):
+        result += "\n"
+    return result


### PR DESCRIPTION
### Motivation
- The previous `strip_comments` implementation treated every `//` as a line-comment marker which removed `//` sequences appearing inside quoted literals (e.g. `"https://..."`).
- Block-comment removal used a regex that could lose newline structure and did not preserve trailing newline behavior required by downstream tools.

### Description
- Replace naive split/regex logic with a quote/escape-aware line-stripping helper `_strip_line_comment` that preserves `//` inside single- and double-quoted strings and respects backslash escapes.
- Reimplement `strip_comments` as a single-pass scanner that handles block comments (`/* ... */`) while preserving newline characters and the original trailing newline when present.
- Update the unit test in `gateware/reference/spade-projects/tools/test_text_filters.py` to add a regression case for quoted `//` and adjust expected outputs for the newline-preserving behavior.
- Modified files: `gateware/reference/spade-projects/tools/text_filters.py` and `gateware/reference/spade-projects/tools/test_text_filters.py`.

### Testing
- Ran the unit tests with `PYTHONPATH=gateware/reference/spade-projects/tools python3 -m unittest gateware/reference/spade-projects/tools/test_text_filters.py` and all tests passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7621c0f5883318ffa5aa9c6ab2cdb)