### PR TITLE
Protect key matrix state from external mutation

### DIFF
--- a/py/z80bus/key_matrix.py
+++ b/py/z80bus/key_matrix.py
@@ -67,9 +67,10 @@ class KeyMatrixInterpreter:
         )
 
     def pressed_keys(self) -> list[PressedKey]:
+        keys = self.last_full_state.copy()
         if self.last_shift_state:
-            return self.last_full_state + [PressedKey.shift()]
-        return self.last_full_state
+            keys.append(PressedKey.shift())
+        return keys
 
     def __str__(self):
         r = []

--- a/py/z80bus/test_key_matrix.py
+++ b/py/z80bus/test_key_matrix.py
@@ -83,3 +83,16 @@ def test_key_matrix_equality_handles_other_types():
     interpreter = KeyMatrixInterpreter()
     assert interpreter == KeyMatrixInterpreter()
     assert interpreter != object()
+
+
+def test_pressed_keys_returns_a_copy():
+    interpreter = eval(
+        out_port(0x01, IOPort.SET_KEY_STROBE_LO)
+        + in_port(0x01, IOPort.KEY_INPUT)
+        + in_port(0x01, IOPort.SHIFT_KEY_INPUT)
+    )
+
+    pressed = interpreter.pressed_keys()
+    pressed.pop()
+
+    assert interpreter.pressed_keys() == [PressedKey(row=0, col=0), PressedKey.shift()]


### PR DESCRIPTION
### Motivation
- Avoid exposing the interpreter's internal mutable list from `KeyMatrixInterpreter.pressed_keys()` so callers cannot accidentally mutate internal state.

### Description
- Change `KeyMatrixInterpreter.pressed_keys()` to return a defensive copy of `last_full_state` and append the SHIFT sentinel to that copy when appropriate in `py/z80bus/key_matrix.py`.
- Add a regression test `test_pressed_keys_returns_a_copy` in `py/z80bus/test_key_matrix.py` that mutates the returned list and asserts the interpreter state is unchanged.

### Testing
- Ran `pytest -q py/z80bus/test_key_matrix.py`, which completed with `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d986faec34833192bf894040acf931)