### PR TITLE
Clean up parser code smells

### DIFF
--- a/py/z80bus/bus_parser.py
+++ b/py/z80bus/bus_parser.py
@@ -302,28 +302,25 @@ class BaseBusParser:
 
 # like BusParser, but only parses type, val, addr
 class SimpleBusParser:
-    def parse(self, data):
-        r = []
+    def parse(self, data: bytes) -> list[Event]:
+        events: list[Event] = []
         offset = 0
         view = memoryview(data)
         while offset + 4 <= len(view):
             chunk = view[offset : offset + 4]
             try:
-                type, val, addr = _decode_event_fields(chunk)
+                event_type, val, addr = _decode_event_fields(chunk)
             except ValueError:
                 offset += 1
                 continue
 
             offset += 4
 
-            r.append(Event(type=type, val=val, addr=addr))
-        return r
+            events.append(Event(type=event_type, val=val, addr=addr))
+        return events
 
 
 class BusParser(BaseBusParser):
-    def __init__(self) -> None:
-        super().__init__()
-
     def parse(self, data):
         errors = []
         events = []


### PR DESCRIPTION
### Motivation
- Avoid shadowing the built-in `type` and improve clarity and intent in the lightweight parser, while removing a redundant initializer.

### Description
- Renamed local `type` variable to `event_type`, renamed accumulator `r` to `events`, and added the signature `def parse(self, data: bytes) -> list[Event]:` in `SimpleBusParser.parse`, and removed the no-op `BusParser.__init__` override in `py/z80bus/bus_parser.py`.

### Testing
- Ran `cd py && pytest z80bus/test_bus_parser.py -q` and all tests passed (`17 passed in 0.17s`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d986faec34833192bf894040acf931)