### PR TITLE
Simplify pipeline instruction state tracking

### DIFF
--- a/py/z80bus/bus_parser.py
+++ b/py/z80bus/bus_parser.py
@@ -425,13 +425,14 @@ class PipelineBusParser(BaseBusParser):
                 continue
             data = data[4:]
 
-            event = self.event(event_type, value, addr)
-
-            if event.type == Type.FETCH:
+            # A fetch starts a new instruction, so flush buffered events before
+            # creating the new event. This keeps instruction state updates
+            # single-sourced in _create_event.
+            if event_type == Type.FETCH:
                 self.flush()
 
+            event = self.event(event_type, value, addr)
             self.buf.append(event)
-            self._record_instruction_event(event)
 
         # return unprocessed data, it should be concatenated with the next batch
         return bytes(data)

--- a/py/z80bus/test_bus_parser.py
+++ b/py/z80bus/test_bus_parser.py
@@ -71,6 +71,24 @@ def test_invalid_parse() -> None:
     not_parse(b"R")
 
 
+def test_pipeline_records_instruction_state_once_per_event() -> None:
+    class RecordingPipelineBusParser(PipelineBusParser):
+        def __init__(self, errors_queue, out_ports_queue):
+            super().__init__(errors_queue, out_ports_queue)
+            self.record_calls = 0
+
+        def _record_instruction_event(self, event: Event) -> None:
+            self.record_calls += 1
+            super()._record_instruction_event(event)
+
+    errors_queue: queue.Queue = queue.Queue()
+    out_ports_queue: queue.Queue = queue.Queue()
+    parser = RecordingPipelineBusParser(errors_queue, out_ports_queue)
+    parser.parse(fetch(0xCD, 0x1234) + read(0x12, 0x1235))
+
+    assert parser.record_calls == 2
+
+
 # helper functions to construct fake transmitted bytes
 def read(val: int, addr: int) -> bytes:
     return b"R" + struct.pack("B", val) + struct.pack("<H", addr)


### PR DESCRIPTION
### Motivation
- `PipelineBusParser.parse` implicitly caused instruction-state updates in two places which created a code smell of duplicated/fragile state handling across `parse` and `_create_event`.

### Description
- Flush buffered instruction events when a `FETCH` is decoded (call `flush()` before creating the new event) to make instruction boundaries explicit in `PipelineBusParser.parse`.
- Ensure `_create_event` remains the single place that records instruction state by removing duplicated recording from the parse flow in `py/z80bus/bus_parser.py`.
- Add a regression test `test_pipeline_records_instruction_state_once_per_event` in `py/z80bus/test_bus_parser.py` to assert instruction-state recording is invoked exactly once per parsed event.

### Testing
- Ran `pytest -q py/z80bus/test_bus_parser.py` which completed successfully with `18 passed`.
- The added regression test verifies the pipeline parser records instruction state exactly once per event and is included in the above test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d986faec34833192bf894040acf931)