### PR TITLE
Add common Spade boot banners

### DIFF
--- a/gateware/reference/binary-counter/.gitignore
+++ b/gateware/reference/binary-counter/.gitignore
@@ -1,4 +1,5 @@
 build/
+src/build_info.spade
 .venv-host/
 test/dump.vcd
 test/results.xml

--- a/gateware/reference/binary-counter/src/main.spade
+++ b/gateware/reference/binary-counter/src/main.spade
@@ -1,4 +1,11 @@
-use shared_components::{ascii::DigitDecode, primitives::reset_conditioner, serial::{uart_rx, uart_tx}};
+mod build_info;
+
+use shared_components::{
+    ascii::DigitDecode,
+    boot_banner::boot_banner_core,
+    primitives::reset_conditioner,
+    serial::{uart_rx, uart_tx},
+};
 
 fn default_digit_decode() -> DigitDecode {
     DigitDecode$(valid: false, value: 0)
@@ -52,8 +59,30 @@ entity main(
     let rx_out = inst uart_rx(clk, rst, usb_rx, 100, false, 1);
     let rx_digit = inst decode_rx_digit(clk, rx_out.valid, rx_out.parity_error, rx_out.byte)
         .unwrap_or(default_digit_decode());
-    let tx_out = inst uart_tx::<100_000_000, 1_000_000, 8>(clk, rst, false, rx_out.byte, rx_digit.valid);
-    let accepted_digit = rx_digit.valid && !tx_out.busy;
+    let (tx_line, tx_line_w): (&bool, inv &bool) = port;
+    let (tx_busy, tx_busy_w): (&bool, inv &bool) = port;
+    let boot_banner_out = inst boot_banner_core::<8, 84>(
+        clk,
+        rst,
+        build_info::boot_banner_text(),
+        *tx_busy,
+    );
+    let tx_data = if boot_banner_out.tx_req.valid {
+        boot_banner_out.tx_req.byte
+    } else {
+        rx_out.byte
+    };
+    let tx_valid = boot_banner_out.tx_req.valid || rx_digit.valid;
+    let tx_out = inst uart_tx::<100_000_000, 1_000_000, 8>(
+        clk,
+        rst,
+        false,
+        tx_data,
+        tx_valid,
+    );
+    set tx_line_w = &tx_out.tx;
+    set tx_busy_w = &tx_out.busy;
+    let accepted_digit = rx_digit.valid && !*tx_busy && !boot_banner_out.tx_req.valid;
 
     reg(clk) slow_factor: uint<4> reset(rst: 0) = {
         if accepted_digit {
@@ -84,5 +113,5 @@ entity main(
     let bits = counter.to_bits();
     set led = &bits;
     set saleae = &bits;
-    set usb_tx = &tx_out.tx;
+    set usb_tx = &*tx_line;
 }

--- a/gateware/reference/binary-counter/swim.toml
+++ b/gateware/reference/binary-counter/swim.toml
@@ -1,4 +1,5 @@
 name = "binary_counter"
+preprocessing = ["python3 ../spade-projects/tools/gen_build_info.py --project ."]
 
 [libraries]
 shared_components = { path = "../spade-projects/shared-components" }

--- a/gateware/reference/binary-counter/test/counter_pins.py
+++ b/gateware/reference/binary-counter/test/counter_pins.py
@@ -83,15 +83,48 @@ async def send_uart_byte(dut, value):
     await tick(dut.clk, BIT_CYCLES)
 
 
-async def recv_uart_byte(dut, timeout_cycles=BIT_CYCLES * 50):
-    model = AlchitryUartRxModel(bit_time=BIT_CYCLES)
+async def wait_uart_start_fall(dut, timeout_cycles=BIT_CYCLES * 120):
+    if int(dut.usb_tx.value) == 0:
+        return
+    prev = int(dut.usb_tx.value)
     for _ in range(timeout_cycles):
         await tick(dut.clk, 1)
-        valid, value = model.step(int(dut.usb_tx.value))
-        if valid:
-            return value
+        cur = int(dut.usb_tx.value)
+        if prev == 1 and cur == 0:
+            return
+        prev = cur
 
-    assert False, "timed out waiting for uart echo"
+    assert False, "timed out waiting for UART start bit"
+
+
+async def recv_uart_byte(dut, timeout_cycles=BIT_CYCLES * 120):
+    await wait_uart_start_fall(dut, timeout_cycles)
+    await tick(dut.clk, BIT_CYCLES + (BIT_CYCLES // 2))
+
+    value = 0
+    for bit_idx in range(8):
+        value |= int(dut.usb_tx.value) << bit_idx
+        await tick(dut.clk, BIT_CYCLES)
+
+    stop = int(dut.usb_tx.value)
+    assert stop == 1, f"invalid UART stop bit: {stop}"
+    await tick(dut.clk, BIT_CYCLES // 2)
+    return value
+
+
+async def recv_uart_line(dut, timeout_cycles=BIT_CYCLES * 120, max_len=160):
+    data = bytearray()
+    for _ in range(max_len):
+        data.append(await recv_uart_byte(dut, timeout_cycles))
+        if data[-1] == 0x0A:
+            return data.decode("ascii", errors="replace")
+    assert False, f"line too long without LF: {data!r}"
+
+
+async def expect_boot_banner(dut):
+    line = await recv_uart_line(dut, timeout_cycles=BIT_CYCLES * 220)
+    assert line.startswith("RBXBOOT project=binary-counter git="), f"unexpected boot banner: {line!r}"
+    assert " dirty=" in line and " built=" in line and line.endswith("\r\n"), f"malformed boot banner: {line!r}"
 
 
 async def assert_no_uart_echo(dut, cycles):
@@ -154,6 +187,7 @@ async def uart_digit_controls_led_saleae_slow_factor(dut):
     assert read_u8(dut.saleae) == 0
 
     dut.rst_n.value = 1
+    await expect_boot_banner(dut)
     await wait_for_tx_idle_high(dut)
 
     fast_intervals = await measure_led_change_intervals(dut, count=8, max_cycles=40)
@@ -185,6 +219,7 @@ async def non_digit_is_ignored_and_not_echoed(dut):
     dut.usb_rx.value = 1
     await tick(dut.clk, 8)
     dut.rst_n.value = 1
+    await expect_boot_banner(dut)
     await wait_for_tx_idle_high(dut)
 
     baseline = await measure_led_change_intervals(dut, count=6, max_cycles=30)

--- a/gateware/reference/spade-projects/ft-uart-hex-bridge-spade/src/main.spade
+++ b/gateware/reference/spade-projects/ft-uart-hex-bridge-spade/src/main.spade
@@ -3,6 +3,7 @@ mod msg;
 mod protocol;
 
 use shared_components::{
+    boot_banner::boot_banner_core,
     clocking::sampled_bool_clock,
     config::{au_ft_tap_u16, au_usb_uart_rx, au_usb_uart_tx8_tap},
     primitives::reset_conditioner,
@@ -297,19 +298,30 @@ entity main_core(
         rx_empty,
         rx_dout,
     );
+    let boot_banner_out = inst boot_banner_core::<8, 94>(
+        clk,
+        rst,
+        build_info::boot_banner_text(),
+        *usb_busy,
+    );
     let msg_stream = bridge_msg_stream_step(
         state.msg_stream,
-        *usb_busy,
+        *usb_busy || boot_banner_out.tx_req.valid,
         msg_decision.next_msg_valid,
         msg_decision.next_msg,
     );
+    let usb_tx_req = if boot_banner_out.tx_req.valid {
+        boot_banner_out.tx_req
+    } else {
+        msg_stream.tx_req
+    };
 
     let _usb_tx = inst au_usb_uart_tx8_tap(
         clk,
         rst,
         false,
-        msg_stream.tx_req.byte,
-        msg_stream.tx_req.valid,
+        usb_tx_req.byte,
+        usb_tx_req.valid,
         usb_tx_line_w,
         usb_busy_w,
     );

--- a/gateware/reference/spade-projects/ft-uart-hex-bridge-spade/src/main.spade
+++ b/gateware/reference/spade-projects/ft-uart-hex-bridge-spade/src/main.spade
@@ -3,7 +3,7 @@ mod msg;
 mod protocol;
 
 use shared_components::{
-    boot_banner::boot_banner_core,
+    boot_banner::{boot_banner_then_tx_req, boot_banner_tx_gate},
     clocking::sampled_bool_clock,
     config::{au_ft_tap_u16, au_usb_uart_rx, au_usb_uart_tx8_tap},
     primitives::reset_conditioner,
@@ -298,7 +298,7 @@ entity main_core(
         rx_empty,
         rx_dout,
     );
-    let boot_banner_out = inst boot_banner_core::<8, 94>(
+    let boot_tx = inst boot_banner_tx_gate::<8, 94>(
         clk,
         rst,
         build_info::boot_banner_text(),
@@ -306,15 +306,11 @@ entity main_core(
     );
     let msg_stream = bridge_msg_stream_step(
         state.msg_stream,
-        *usb_busy || boot_banner_out.tx_req.valid,
+        boot_tx.app_tx_busy,
         msg_decision.next_msg_valid,
         msg_decision.next_msg,
     );
-    let usb_tx_req = if boot_banner_out.tx_req.valid {
-        boot_banner_out.tx_req
-    } else {
-        msg_stream.tx_req
-    };
+    let usb_tx_req = boot_banner_then_tx_req(boot_tx.tx_req, msg_stream.tx_req);
 
     let _usb_tx = inst au_usb_uart_tx8_tap(
         clk,

--- a/gateware/reference/spade-projects/ft-uart-hex-bridge-spade/test/test_ft_uart_hex_bridge.py
+++ b/gateware/reference/spade-projects/ft-uart-hex-bridge-spade/test/test_ft_uart_hex_bridge.py
@@ -5,6 +5,7 @@ from cocotb.triggers import FallingEdge
 from cocotb.triggers import RisingEdge
 from cocotb.triggers import Timer
 
+from boot_banner_test import assert_boot_banner
 from cocotb_helpers import start_clock
 from cocotb_helpers import tick
 
@@ -92,8 +93,7 @@ async def _uart_recv_line(dut, timeout_cycles: int = USB_UART_BIT_CYCLES * 150, 
 
 async def _expect_boot_banner(dut, project_name: str) -> None:
     line = await _uart_recv_line(dut, timeout_cycles=USB_UART_BIT_CYCLES * 220)
-    assert line.startswith(f"RBXBOOT project={project_name} git="), f"unexpected boot banner: {line!r}"
-    assert " dirty=" in line and " built=" in line and line.endswith("\r\n"), f"malformed boot banner: {line!r}"
+    assert_boot_banner(line, project_name)
 
 
 async def _ft_host_send_word_be(dut, word: int, be: int, timeout_cycles: int = 2000):

--- a/gateware/reference/spade-projects/ft-uart-hex-bridge-spade/test/test_ft_uart_hex_bridge.py
+++ b/gateware/reference/spade-projects/ft-uart-hex-bridge-spade/test/test_ft_uart_hex_bridge.py
@@ -31,6 +31,7 @@ async def _init(dut):
     await tick(dut.clk, 8)
     dut.rst_n.value = 1
     await tick(dut.clk, 12)
+    await _expect_boot_banner(dut, "ft-uart-hex-bridge-spade")
 
 
 async def _uart_send_byte(dut, value: int):
@@ -87,6 +88,12 @@ async def _uart_recv_line(dut, timeout_cycles: int = USB_UART_BIT_CYCLES * 150, 
         if data[-1] == 0x0A:
             return data.decode("ascii", errors="replace")
     raise AssertionError(f"line too long without LF: {data!r}")
+
+
+async def _expect_boot_banner(dut, project_name: str) -> None:
+    line = await _uart_recv_line(dut, timeout_cycles=USB_UART_BIT_CYCLES * 220)
+    assert line.startswith(f"RBXBOOT project={project_name} git="), f"unexpected boot banner: {line!r}"
+    assert " dirty=" in line and " built=" in line and line.endswith("\r\n"), f"malformed boot banner: {line!r}"
 
 
 async def _ft_host_send_word_be(dut, word: int, be: int, timeout_cycles: int = 2000):

--- a/gateware/reference/spade-projects/pin-tester-spade/src/main.spade
+++ b/gateware/reference/spade-projects/pin-tester-spade/src/main.spade
@@ -1,5 +1,5 @@
 mod build_info;
-use shared_components::{primitives::counter, serial::usb_loopback};
+use shared_components::{boot_banner::au_usb_uart_banner_then_loopback, primitives::counter};
 
 #[no_mangle(all)]
 entity main(
@@ -21,5 +21,11 @@ entity main(
     set led = &led_bits;
     set saleae = &led_bits;
     set ffc_data = &ffc_bits;
-    let _ = inst usb_loopback(usb_rx, usb_tx);
+    inst au_usb_uart_banner_then_loopback::<8, 86>(
+        clk,
+        rst,
+        usb_rx,
+        build_info::boot_banner_text(),
+        usb_tx,
+    );
 }

--- a/gateware/reference/spade-projects/shared-components/src/boot_banner.spade
+++ b/gateware/reference/spade-projects/shared-components/src/boot_banner.spade
@@ -1,4 +1,7 @@
-use super::message_stream::{TxReq8, tx_req_none};
+use super::{
+    config::{au_usb_uart_rx, au_usb_uart_tx8_tap},
+    message_stream::{TxReq8, tx_req_none},
+};
 
 pub struct BootBannerState<#uint IDX_W> {
     active: bool,
@@ -38,4 +41,56 @@ pub fn boot_banner_step<#uint IDX_W, #uint N>(
             tx_req: TxReq8$(valid: true, byte: banner[trunc(state.idx)]),
         )
     }
+}
+
+#[inline]
+pub entity boot_banner_core<#uint IDX_W, #uint N>(
+    clk: clock,
+    rst: bool,
+    banner: [uint<8>; N],
+    block_tx: bool,
+) -> BootBannerOut<IDX_W> {
+    reg(clk) state: BootBannerState<IDX_W> reset(rst: init_boot_banner()) = {
+        boot_banner_step(state, banner, block_tx).state
+    };
+
+    boot_banner_step(state, banner, block_tx)
+}
+
+#[inline]
+pub entity au_usb_uart_banner_then_loopback<#uint IDX_W, #uint N>(
+    clk: clock,
+    rst: bool,
+    usb_rx: bool,
+    banner: [uint<8>; N],
+    usb_tx: inv &bool,
+) {
+    let (tx_line, tx_line_w): (&bool, inv &bool) = port;
+    let (tx_busy, tx_busy_w): (&bool, inv &bool) = port;
+    let rx = inst au_usb_uart_rx(clk, rst, usb_rx);
+    let banner_out = inst boot_banner_core::<IDX_W, N>(
+        clk,
+        rst,
+        banner,
+        *tx_busy,
+    );
+    let banner_active = banner_out.tx_req.valid;
+    let tx_data = if banner_active {
+        banner_out.tx_req.byte
+    } else {
+        rx.byte
+    };
+    let tx_valid = banner_active || rx.valid;
+
+    inst au_usb_uart_tx8_tap(
+        clk,
+        rst,
+        false,
+        tx_data,
+        tx_valid,
+        tx_line_w,
+        tx_busy_w,
+    );
+
+    set usb_tx = &*tx_line;
 }

--- a/gateware/reference/spade-projects/shared-components/src/boot_banner.spade
+++ b/gateware/reference/spade-projects/shared-components/src/boot_banner.spade
@@ -13,6 +13,11 @@ pub struct BootBannerOut<#uint IDX_W> {
     tx_req: TxReq8,
 }
 
+pub struct BootBannerTxGateOut {
+    tx_req: TxReq8,
+    app_tx_busy: bool,
+}
+
 pub fn init_boot_banner<#uint IDX_W>() -> BootBannerState<IDX_W> {
     BootBannerState$(
         active: true,
@@ -55,6 +60,34 @@ pub entity boot_banner_core<#uint IDX_W, #uint N>(
     };
 
     boot_banner_step(state, banner, block_tx)
+}
+
+#[inline]
+pub entity boot_banner_tx_gate<#uint IDX_W, #uint N>(
+    clk: clock,
+    rst: bool,
+    banner: [uint<8>; N],
+    tx_busy: bool,
+) -> BootBannerTxGateOut {
+    let banner_out = inst boot_banner_core::<IDX_W, N>(
+        clk,
+        rst,
+        banner,
+        tx_busy,
+    );
+
+    BootBannerTxGateOut$(
+        tx_req: banner_out.tx_req,
+        app_tx_busy: tx_busy || banner_out.tx_req.valid,
+    )
+}
+
+pub fn boot_banner_then_tx_req(banner_tx_req: TxReq8, app_tx_req: TxReq8) -> TxReq8 {
+    if banner_tx_req.valid {
+        banner_tx_req
+    } else {
+        app_tx_req
+    }
 }
 
 #[inline]

--- a/gateware/reference/spade-projects/shared-components/src/serial.spade
+++ b/gateware/reference/spade-projects/shared-components/src/serial.spade
@@ -156,7 +156,7 @@ pub entity uart_tx<#uint CLK_FREQ, #uint BAUD, #uint DATA_WIDTH>(
     let ctr_last = clk_per_bit - 1;
 
     reg(clk) regs: UartTxRegs<DATA_WIDTH>
-        reset(rst: UartTxRegs$(state: UartTxState::Idle(), ctr: 0, bit_ctr: 0, saved_data: 0, tx_reg: false, block_flag: false))
+        reset(rst: UartTxRegs$(state: UartTxState::Idle(), ctr: 0, bit_ctr: 0, saved_data: 0, tx_reg: true, block_flag: false))
         = {
             let state = regs.state;
             let ctr = regs.ctr;

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/src/main.spade
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/src/main.spade
@@ -8,7 +8,7 @@ mod render;
 mod transport;
 
 use shared_components::{
-    boot_banner::boot_banner_core,
+    boot_banner::boot_banner_tx_gate,
     clocking::{clk_wiz_400, sampled_bool_clock},
     config::au_usb_uart_rx,
     ft_stream::{FtWordStreamOut, FtWordStreamState, ft_word_stream_step},
@@ -330,7 +330,7 @@ entity main_core(
     let (stream_fifo_dout, stream_fifo_dout_w): (&OrganizerTraceWord, inv &OrganizerTraceWord) = port;
 
     let rx = inst au_usb_uart_rx(clk, rst, usb_rx);
-    let boot_banner_out = inst boot_banner_core::<8, 96>(
+    let boot_tx = inst boot_banner_tx_gate::<8, 96>(
         clk,
         rst,
         build_info::boot_banner_text(),
@@ -343,7 +343,7 @@ entity main_core(
         misc_sync: misc_sync,
         rx_valid: rx.valid,
         rx_byte: rx.byte,
-        tx_busy: *usb_tx_busy || boot_banner_out.tx_req.valid,
+        tx_busy: boot_tx.app_tx_busy,
         ft_ui_din_full: *ft_ui_din_full,
         ft_ui_dout_empty: *ft_ui_dout_empty,
         ft_ui_dout: *ft_ui_dout,
@@ -361,7 +361,7 @@ entity main_core(
         };
 
     let eval = state.eval(inputs);
-    let usb_tx_req = tx_req_arbiter(boot_banner_out.tx_req, eval.tx_req, tx_req_none());
+    let usb_tx_req = tx_req_arbiter(boot_tx.tx_req, eval.tx_req, tx_req_none());
     inst organizer_transport(
         clk,
         rst,

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/src/main.spade
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/src/main.spade
@@ -8,10 +8,11 @@ mod render;
 mod transport;
 
 use shared_components::{
+    boot_banner::boot_banner_core,
     clocking::{clk_wiz_400, sampled_bool_clock},
     config::au_usb_uart_rx,
     ft_stream::{FtWordStreamOut, FtWordStreamState, ft_word_stream_step},
-    message_stream::TxReq8,
+    message_stream::{TxReq8, tx_req_arbiter, tx_req_none},
     primitives::{reset_conditioner, sync_bundle},
     rv::tx_req_as_rv,
     serial::{FtBe, FtData},
@@ -329,6 +330,12 @@ entity main_core(
     let (stream_fifo_dout, stream_fifo_dout_w): (&OrganizerTraceWord, inv &OrganizerTraceWord) = port;
 
     let rx = inst au_usb_uart_rx(clk, rst, usb_rx);
+    let boot_banner_out = inst boot_banner_core::<8, 96>(
+        clk,
+        rst,
+        build_info::boot_banner_text(),
+        *usb_tx_busy,
+    );
 
     let inputs = MainInputs$(
         addr_sync: addr_sync,
@@ -336,7 +343,7 @@ entity main_core(
         misc_sync: misc_sync,
         rx_valid: rx.valid,
         rx_byte: rx.byte,
-        tx_busy: *usb_tx_busy,
+        tx_busy: *usb_tx_busy || boot_banner_out.tx_req.valid,
         ft_ui_din_full: *ft_ui_din_full,
         ft_ui_dout_empty: *ft_ui_dout_empty,
         ft_ui_dout: *ft_ui_dout,
@@ -354,6 +361,7 @@ entity main_core(
         };
 
     let eval = state.eval(inputs);
+    let usb_tx_req = tx_req_arbiter(boot_banner_out.tx_req, eval.tx_req, tx_req_none());
     inst organizer_transport(
         clk,
         rst,
@@ -362,7 +370,7 @@ entity main_core(
         ft_txe,
         ft_data,
         ft_be,
-        tx_req_as_rv(eval.tx_req),
+        tx_req_as_rv(usb_tx_req),
         eval.stream_word,
         eval.stream_word_valid,
         eval.ft_stream,

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/test/test_sharp_organizer_card.py
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/test/test_sharp_organizer_card.py
@@ -79,6 +79,7 @@ async def _init(dut):
     await tick(dut.clk, 6)
     dut.rst_n.value = 1
     await tick(dut.clk, 10)
+    await _expect_boot_banner(dut, "sharp-organizer-card-spade")
 
 
 async def _uart_send_byte(dut, byte: int):
@@ -122,6 +123,21 @@ async def _uart_recv_byte(dut, timeout_cycles: int = 12000) -> int:
     stop = int(dut.usb_tx.value)
     assert stop == 1, f"invalid USB UART stop bit: {stop}"
     return value
+
+
+async def _uart_recv_line(dut, timeout_cycles: int = USB_UART_BIT_CYCLES * 160, max_len: int = 160) -> str:
+    data = bytearray()
+    for _ in range(max_len):
+        data.append(await _uart_recv_byte(dut, timeout_cycles))
+        if data[-1] == 0x0A:
+            return data.decode("ascii", errors="replace")
+    raise AssertionError(f"line too long without LF: {data!r}")
+
+
+async def _expect_boot_banner(dut, project_name: str) -> None:
+    line = await _uart_recv_line(dut, timeout_cycles=USB_UART_BIT_CYCLES * 220)
+    assert line.startswith(f"RBXBOOT project={project_name} git="), f"unexpected boot banner: {line!r}"
+    assert " dirty=" in line and " built=" in line and line.endswith("\r\n"), f"malformed boot banner: {line!r}"
 
 
 async def _ft_host_send_word(dut, word: int, timeout_cycles: int = 2000):

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/test/test_sharp_organizer_card.py
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/test/test_sharp_organizer_card.py
@@ -5,6 +5,7 @@ from cocotb.triggers import FallingEdge
 from cocotb.triggers import RisingEdge
 from cocotb.triggers import Timer
 
+from boot_banner_test import assert_boot_banner
 from cocotb_helpers import start_clock
 from cocotb_helpers import tick
 
@@ -136,8 +137,7 @@ async def _uart_recv_line(dut, timeout_cycles: int = USB_UART_BIT_CYCLES * 160, 
 
 async def _expect_boot_banner(dut, project_name: str) -> None:
     line = await _uart_recv_line(dut, timeout_cycles=USB_UART_BIT_CYCLES * 220)
-    assert line.startswith(f"RBXBOOT project={project_name} git="), f"unexpected boot banner: {line!r}"
-    assert " dirty=" in line and " built=" in line and line.endswith("\r\n"), f"malformed boot banner: {line!r}"
+    assert_boot_banner(line, project_name)
 
 
 async def _ft_host_send_word(dut, word: int, timeout_cycles: int = 2000):

--- a/gateware/reference/spade-projects/sharp-pc-e500-card-spade/src/main.spade
+++ b/gateware/reference/spade-projects/sharp-pc-e500-card-spade/src/main.spade
@@ -3,7 +3,7 @@ mod msg;
 mod protocol;
 
 use shared_components::{
-    boot_banner::{BootBannerOut, BootBannerState, boot_banner_step, init_boot_banner},
+    boot_banner::{BootBannerOut, boot_banner_core},
     clocking::sampled_bool_clock,
     config::{au_ft_tap_u16, au_usb_uart_rx, au_usb_uart_tx8_tap},
     ft_stream::{FtWordStreamState, ft_word_stream_step},
@@ -795,19 +795,6 @@ fn measure_engine_step(
     )
 }
 
-entity boot_banner_core<#uint IDX_W, #uint N>(
-    clk: clock,
-    rst: bool,
-    banner: [uint<8>; N],
-    block_tx: bool,
-) -> BootBannerOut<IDX_W> {
-    reg(clk) state: BootBannerState<IDX_W> reset(rst: init_boot_banner()) = {
-        boot_banner_step(state, banner, block_tx).state
-    };
-
-    boot_banner_step(state, banner, block_tx)
-}
-
 entity parser_core(
     clk: clock,
     rst: bool,
@@ -1022,7 +1009,7 @@ entity main_core(
 
     let usb_rx_out = inst au_usb_uart_rx(clk, rst, usb_rx);
 
-    let boot_banner_out = inst boot_banner_core::<8, 56>(
+    let boot_banner_out = inst boot_banner_core::<8, 94>(
         clk,
         rst,
         build_info::boot_banner_text(),

--- a/gateware/reference/spade-projects/sharp-pc-e500-card-spade/src/main.spade
+++ b/gateware/reference/spade-projects/sharp-pc-e500-card-spade/src/main.spade
@@ -3,7 +3,7 @@ mod msg;
 mod protocol;
 
 use shared_components::{
-    boot_banner::{BootBannerOut, boot_banner_core},
+    boot_banner::boot_banner_tx_gate,
     clocking::sampled_bool_clock,
     config::{au_ft_tap_u16, au_usb_uart_rx, au_usb_uart_tx8_tap},
     ft_stream::{FtWordStreamState, ft_word_stream_step},
@@ -1009,7 +1009,7 @@ entity main_core(
 
     let usb_rx_out = inst au_usb_uart_rx(clk, rst, usb_rx);
 
-    let boot_banner_out = inst boot_banner_core::<8, 94>(
+    let boot_tx = inst boot_banner_tx_gate::<8, 94>(
         clk,
         rst,
         build_info::boot_banner_text(),
@@ -1225,11 +1225,10 @@ entity main_core(
     set sampled_bus_fifo_empty_w = &sampled_bus_fifo.empty;
     set sampled_bus_fifo_dout_w = &sampled_bus_fifo.dout;
 
-    let boot_tx_busy = *usb_tx_busy || boot_banner_out.tx_req.valid;
     let echo_out = inst echo_stream_core(
         clk,
         rst,
-        boot_tx_busy,
+        boot_tx.app_tx_busy,
         parser_front.echo.as_option(),
     );
     let ce6_port_write_valid = ce6_ctrl_write_event && ce6_ctrl_step_addr.ctrl.is_uart_port();
@@ -1452,7 +1451,7 @@ entity main_core(
     };
     let measure_report_wput = measure_pending.pending_valid && !*measure_fifo_full;
     let measure_report_drop = measure_report_capture && measure_pending.pending_valid && *measure_fifo_full;
-    let measure_block_tx = boot_tx_busy || echo_out.tx_req.valid;
+    let measure_block_tx = boot_tx.app_tx_busy || echo_out.tx_req.valid;
     let measure_eval = inst measure_engine_core(
         clk,
         rst,
@@ -1566,7 +1565,7 @@ entity main_core(
     );
     let usb_tx_low_req = tx_req_arbiter(resp_out.tx_req, port_char_tx_req, port_out.tx_req);
     let usb_tx_mid_req = tx_req_arbiter(measure_eval.tx_req, usb_tx_low_req, tx_req_none());
-    let usb_tx_req = tx_req_arbiter(boot_banner_out.tx_req, echo_out.tx_req, usb_tx_mid_req);
+    let usb_tx_req = tx_req_arbiter(boot_tx.tx_req, echo_out.tx_req, usb_tx_mid_req);
 
     let _addr_uart = inst uart_tx_tap::<100_000_000, 100_000_000, 18>(
         clk,

--- a/gateware/reference/spade-projects/sharp-pc-g850-bus-spade/src/main.spade
+++ b/gateware/reference/spade-projects/sharp-pc-g850-bus-spade/src/main.spade
@@ -2,7 +2,7 @@ mod build_info;
 mod console;
 
 use shared_components::{
-    boot_banner::boot_banner_core,
+    boot_banner::boot_banner_tx_gate,
     bridges::{BridgePolicy, UartBridgeOut},
     bus_debug::{
         BusAddr,
@@ -607,7 +607,7 @@ entity main_core(
         *ft_ui_dout,
     );
 
-    let boot_banner_out = inst boot_banner_core::<8, 93>(
+    let boot_tx = inst boot_banner_tx_gate::<8, 93>(
         clk,
         rst,
         build_info::boot_banner_text(),
@@ -618,7 +618,7 @@ entity main_core(
         cycle_decode: cycle_decode,
         rx_valid: rx.valid,
         rx_byte: rx.byte,
-        tx_busy: *tx_busy || boot_banner_out.tx_req.valid,
+        tx_busy: boot_tx.app_tx_busy,
         mreq_fall: mreq_fall,
         iorq_fall: iorq_fall,
         rd_rise: rd_rise,
@@ -644,7 +644,7 @@ entity main_core(
     let bus_sample = eval.bus_sample;
     let ft_mux = eval.ft_mux;
     let usb_cmd = eval.usb_cmd;
-    let usb_tx_req = tx_req_arbiter(boot_banner_out.tx_req, usb_cmd.tx_req, tx_req_none());
+    let usb_tx_req = tx_req_arbiter(boot_tx.tx_req, usb_cmd.tx_req, tx_req_none());
 
     let _tx = inst au_usb_uart_tx8_rv_tap(
         clk,

--- a/gateware/reference/spade-projects/sharp-pc-g850-bus-spade/src/main.spade
+++ b/gateware/reference/spade-projects/sharp-pc-g850-bus-spade/src/main.spade
@@ -2,6 +2,7 @@ mod build_info;
 mod console;
 
 use shared_components::{
+    boot_banner::boot_banner_core,
     bridges::{BridgePolicy, UartBridgeOut},
     bus_debug::{
         BusAddr,
@@ -606,11 +607,18 @@ entity main_core(
         *ft_ui_dout,
     );
 
+    let boot_banner_out = inst boot_banner_core::<8, 93>(
+        clk,
+        rst,
+        build_info::boot_banner_text(),
+        *tx_busy,
+    );
+
     let inputs = MainInputs$(
         cycle_decode: cycle_decode,
         rx_valid: rx.valid,
         rx_byte: rx.byte,
-        tx_busy: *tx_busy,
+        tx_busy: *tx_busy || boot_banner_out.tx_req.valid,
         mreq_fall: mreq_fall,
         iorq_fall: iorq_fall,
         rd_rise: rd_rise,
@@ -636,12 +644,13 @@ entity main_core(
     let bus_sample = eval.bus_sample;
     let ft_mux = eval.ft_mux;
     let usb_cmd = eval.usb_cmd;
+    let usb_tx_req = tx_req_arbiter(boot_banner_out.tx_req, usb_cmd.tx_req, tx_req_none());
 
     let _tx = inst au_usb_uart_tx8_rv_tap(
         clk,
         rst,
         false,
-        tx_req_as_rv(usb_cmd.tx_req),
+        tx_req_as_rv(usb_tx_req),
         tx_line_w,
         tx_busy_w,
     );

--- a/gateware/reference/spade-projects/sharp-pc-g850-bus-spade/test/test_sharp_pc_g850_bus.py
+++ b/gateware/reference/spade-projects/sharp-pc-g850-bus-spade/test/test_sharp_pc_g850_bus.py
@@ -1,6 +1,7 @@
 # top = main
 
 import cocotb
+from boot_banner_test import assert_boot_banner
 from cocotb_helpers import start_clock
 from cocotb_helpers import tick
 from cocotb.triggers import FallingEdge
@@ -162,9 +163,7 @@ async def _uart_recv_lines(dut, count: int) -> list[bytes]:
 
 
 async def _expect_boot_banner(dut, project_name: str) -> None:
-    line = (await _uart_recv_line(dut, max_bytes=160)).decode("ascii", errors="replace")
-    assert line.startswith(f"RBXBOOT project={project_name} git="), f"unexpected boot banner: {line!r}"
-    assert " dirty=" in line and " built=" in line and line.endswith("\r\n"), f"malformed boot banner: {line!r}"
+    assert_boot_banner(await _uart_recv_line(dut, max_bytes=160), project_name)
 
 
 @cocotb.test()

--- a/gateware/reference/spade-projects/sharp-pc-g850-bus-spade/test/test_sharp_pc_g850_bus.py
+++ b/gateware/reference/spade-projects/sharp-pc-g850-bus-spade/test/test_sharp_pc_g850_bus.py
@@ -64,6 +64,7 @@ async def _init(dut):
     await tick(dut.clk, 6)
     dut.rst_n.value = 1
     await tick(dut.clk, 10)
+    await _expect_boot_banner(dut, "sharp-pc-g850-bus-spade")
 
 
 async def _ft_host_send_word(dut, word: int, timeout_cycles: int = 2000):
@@ -115,6 +116,8 @@ async def _uart_send_text(dut, text: str):
 
 
 async def _uart_wait_start_fall(dut, timeout_cycles: int) -> None:
+    if int(dut.usb_tx.value) == 0:
+        return
     prev = int(dut.usb_tx.value)
     for _ in range(timeout_cycles):
         cur = int(dut.usb_tx.value)
@@ -138,6 +141,7 @@ async def _uart_recv_byte(dut, timeout_cycles: int = 12000) -> int:
 
     stop = int(dut.usb_tx.value)
     assert stop == 1, f"invalid UART stop bit: {stop}"
+    await tick(dut.clk, CLK_PER_UART_BIT // 2)
     return value
 
 
@@ -155,6 +159,12 @@ async def _uart_recv_lines(dut, count: int) -> list[bytes]:
     for _ in range(count):
         lines.append(await _uart_recv_line(dut))
     return lines
+
+
+async def _expect_boot_banner(dut, project_name: str) -> None:
+    line = (await _uart_recv_line(dut, max_bytes=160)).decode("ascii", errors="replace")
+    assert line.startswith(f"RBXBOOT project={project_name} git="), f"unexpected boot banner: {line!r}"
+    assert " dirty=" in line and " built=" in line and line.endswith("\r\n"), f"malformed boot banner: {line!r}"
 
 
 @cocotb.test()

--- a/gateware/reference/spade-projects/sharp-pc-g850-streaming-rom-spade/src/main.spade
+++ b/gateware/reference/spade-projects/sharp-pc-g850-streaming-rom-spade/src/main.spade
@@ -1,8 +1,9 @@
 mod build_info;
 use shared_components::{
+    boot_banner::au_usb_uart_banner_then_loopback,
     clocking::clk_wiz_400,
     sharp::{banked_rom_byte, count_on_event, gate_byte8},
-    serial::{ft_aux_activity, usb_loopback},
+    serial::ft_aux_activity,
 };
 
 #[no_mangle(all)]
@@ -52,7 +53,13 @@ entity main(
     let aux = ft_aux || z80_wait || z80_m1 || z80_ioreset || z80_int1;
 
     set data = &out_byte;
-    let _ = inst usb_loopback(usb_rx, usb_tx);
+    inst au_usb_uart_banner_then_loopback::<8, 103>(
+        clk,
+        rst,
+        usb_rx,
+        build_info::boot_banner_text(),
+        usb_tx,
+    );
     set ft_rd = &!ft_rxf;
     set ft_wr = &false;
     set ft_oe = &false;

--- a/gateware/reference/spade-projects/tools/boot_banner_test.py
+++ b/gateware/reference/spade-projects/tools/boot_banner_test.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+def assert_boot_banner(line: bytes | str, project_name: str) -> None:
+    if isinstance(line, bytes):
+        text = line.decode("ascii", errors="replace")
+    else:
+        text = line
+
+    assert text.startswith(f"RBXBOOT project={project_name} git="), f"unexpected boot banner: {text!r}"
+    assert " dirty=" in text and " built=" in text and text.endswith("\r\n"), f"malformed boot banner: {text!r}"

--- a/gateware/reference/spade-projects/tools/gen_build_info.py
+++ b/gateware/reference/spade-projects/tools/gen_build_info.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
@@ -43,7 +44,42 @@ def build_timestamp_text() -> str:
         dt = datetime.fromtimestamp(int(source_date_epoch), UTC)
     else:
         dt = datetime.now(UTC)
-    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run_git(project: Path, *args: str) -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(project), *args],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def git_status_dirty(project: Path) -> bool:
+    root_text = run_git(project, "rev-parse", "--show-toplevel")
+    status_text = run_git(project, "status", "--porcelain")
+    if not root_text or not status_text:
+        return False
+
+    root = Path(root_text).resolve()
+    generated = {
+        str((project / "src" / "build_info.spade").resolve().relative_to(root)),
+        str((project / "build" / "build_info.json").resolve().relative_to(root)),
+    }
+    for raw in status_text.splitlines():
+        path = raw[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path not in generated:
+            return True
+    return False
+
+
+def git_hash_text(project: Path) -> str:
+    return run_git(project, "rev-parse", "--short=12", "HEAD") or "000000000000"
 
 
 def spade_bytes_literal(text: str) -> str:
@@ -57,15 +93,21 @@ def spade_bytes_literal(text: str) -> str:
     return f'b"{escaped}"'
 
 
-def render_build_info_module(project_name: str, build_timestamp: str) -> str:
-    banner = f"{project_name} built {build_timestamp}\r\n"
-    banner_len = len(project_name) + len(build_timestamp) + len(" built \r\n")
+def render_build_info_module(project_name: str, build_timestamp: str, git_hash: str, dirty_text: str) -> str:
+    banner = f"RBXBOOT project={project_name} git={git_hash} dirty={dirty_text} built={build_timestamp}\r\n"
+    banner_len = len(banner)
     return (
         f"pub fn project_name_text() -> [uint<8>; {len(project_name)}] {{\n"
         f"    {spade_bytes_literal(project_name)}\n"
         "}\n\n"
         f"pub fn build_timestamp_text() -> [uint<8>; {len(build_timestamp)}] {{\n"
         f"    {spade_bytes_literal(build_timestamp)}\n"
+        "}\n\n"
+        f"pub fn git_hash_text() -> [uint<8>; {len(git_hash)}] {{\n"
+        f"    {spade_bytes_literal(git_hash)}\n"
+        "}\n\n"
+        f"pub fn dirty_text() -> [uint<8>; {len(dirty_text)}] {{\n"
+        f"    {spade_bytes_literal(dirty_text)}\n"
         "}\n\n"
         f"pub fn boot_banner_text() -> [uint<8>; {banner_len}] {{\n"
         f"    {spade_bytes_literal(banner)}\n"
@@ -78,11 +120,13 @@ def main() -> int:
     project = args.project.resolve()
     project_name = project_display_name(project)
     build_timestamp = build_timestamp_text()
-    banner = f"{project_name} built {build_timestamp}\r\n"
+    git_hash = git_hash_text(project)
+    dirty_text = "1" if git_status_dirty(project) else "0"
+    banner = f"RBXBOOT project={project_name} git={git_hash} dirty={dirty_text} built={build_timestamp}\r\n"
 
     src_path = project / "src" / "build_info.spade"
     src_path.parent.mkdir(parents=True, exist_ok=True)
-    src_path.write_text(render_build_info_module(project_name, build_timestamp))
+    src_path.write_text(render_build_info_module(project_name, build_timestamp, git_hash, dirty_text))
 
     build_path = project / "build" / "build_info.json"
     build_path.parent.mkdir(parents=True, exist_ok=True)
@@ -91,6 +135,8 @@ def main() -> int:
             {
                 "project_name": project_name,
                 "build_timestamp": build_timestamp,
+                "git_hash": git_hash,
+                "dirty": dirty_text == "1",
                 "banner": banner,
             },
             indent=2,

--- a/gateware/reference/spade-projects/uart-saleae-loopback-spade/src/main.spade
+++ b/gateware/reference/spade-projects/uart-saleae-loopback-spade/src/main.spade
@@ -1,6 +1,6 @@
 mod build_info;
 use shared_components::{
-    boot_banner::boot_banner_core,
+    boot_banner::boot_banner_tx_gate,
     bridges::BridgePolicy,
     clocking::{clk_wiz_200_400, sampled_bool_clock},
     config::{au_dual_bridge_u8x8_100_200, au_usb_uart_rx, au_usb_uart_tx8_tap},
@@ -27,7 +27,7 @@ entity main(
 
     let (enqueue, enqueue_w): (&bool, inv &bool) = port;
     let (usb_uart, usb_uart_w): (UartLineBusyPort, inv UartLineBusyPort) = port;
-    let boot_banner_out = inst boot_banner_core::<8, 96>(
+    let boot_tx = inst boot_banner_tx_gate::<8, 96>(
         clk,
         rst,
         build_info::boot_banner_text(),
@@ -40,7 +40,7 @@ entity main(
         rx.valid,
         rx.parity_error,
         rx.byte,
-        *usb_uart.busy || boot_banner_out.tx_req.valid,
+        boot_tx.app_tx_busy,
     );
 
     let mode_is_echo = cmd_core.mode.is_echo();
@@ -62,13 +62,13 @@ entity main(
     let rx_is_payload = cmd_core.payload_rx;
 
     let all_fifo_ready = !tx6_bridge.fifo_full && !tx7_bridge.fifo_full;
-    let can_accept = rx_is_payload && cmd_core.tx_msg_none && !*usb_uart.busy && !boot_banner_out.tx_req.valid && all_fifo_ready;
+    let can_accept = rx_is_payload && cmd_core.tx_msg_none && !boot_tx.app_tx_busy && all_fifo_ready;
     let dropped = rx_is_payload && !can_accept;
     set enqueue_w = &can_accept;
 
-    let tx_new_data = boot_banner_out.tx_req.valid || cmd_core.tx_req.valid || can_accept;
-    let tx_data = if boot_banner_out.tx_req.valid {
-        boot_banner_out.tx_req.byte
+    let tx_new_data = boot_tx.tx_req.valid || cmd_core.tx_req.valid || can_accept;
+    let tx_data = if boot_tx.tx_req.valid {
+        boot_tx.tx_req.byte
     } else if cmd_core.tx_req.valid {
         cmd_core.tx_req.byte
     } else if can_accept {

--- a/gateware/reference/spade-projects/uart-saleae-loopback-spade/src/main.spade
+++ b/gateware/reference/spade-projects/uart-saleae-loopback-spade/src/main.spade
@@ -1,5 +1,6 @@
 mod build_info;
 use shared_components::{
+    boot_banner::boot_banner_core,
     bridges::BridgePolicy,
     clocking::{clk_wiz_200_400, sampled_bool_clock},
     config::{au_dual_bridge_u8x8_100_200, au_usb_uart_rx, au_usb_uart_tx8_tap},
@@ -26,6 +27,12 @@ entity main(
 
     let (enqueue, enqueue_w): (&bool, inv &bool) = port;
     let (usb_uart, usb_uart_w): (UartLineBusyPort, inv UartLineBusyPort) = port;
+    let boot_banner_out = inst boot_banner_core::<8, 96>(
+        clk,
+        rst,
+        build_info::boot_banner_text(),
+        *usb_uart.busy,
+    );
 
     let cmd_core = inst simple_cmd_uart_core(
         clk,
@@ -33,7 +40,7 @@ entity main(
         rx.valid,
         rx.parity_error,
         rx.byte,
-        *usb_uart.busy,
+        *usb_uart.busy || boot_banner_out.tx_req.valid,
     );
 
     let mode_is_echo = cmd_core.mode.is_echo();
@@ -55,12 +62,14 @@ entity main(
     let rx_is_payload = cmd_core.payload_rx;
 
     let all_fifo_ready = !tx6_bridge.fifo_full && !tx7_bridge.fifo_full;
-    let can_accept = rx_is_payload && cmd_core.tx_msg_none && !*usb_uart.busy && all_fifo_ready;
+    let can_accept = rx_is_payload && cmd_core.tx_msg_none && !*usb_uart.busy && !boot_banner_out.tx_req.valid && all_fifo_ready;
     let dropped = rx_is_payload && !can_accept;
     set enqueue_w = &can_accept;
 
-    let tx_new_data = cmd_core.tx_req.valid || can_accept;
-    let tx_data = if cmd_core.tx_req.valid {
+    let tx_new_data = boot_banner_out.tx_req.valid || cmd_core.tx_req.valid || can_accept;
+    let tx_data = if boot_banner_out.tx_req.valid {
+        boot_banner_out.tx_req.byte
+    } else if cmd_core.tx_req.valid {
         cmd_core.tx_req.byte
     } else if can_accept {
         rx.byte

--- a/gateware/reference/spade-projects/uart-saleae-loopback-spade/test/test_uart_saleae_loopback.py
+++ b/gateware/reference/spade-projects/uart-saleae-loopback-spade/test/test_uart_saleae_loopback.py
@@ -47,6 +47,9 @@ async def reset_and_capture_ready(dut):
     await tick(dut.clk, 8)
 
     dut.rst_n.value = 1
+    boot = await recv_uart_line(dut)
+    assert boot.startswith("RBXBOOT project=uart-saleae-loopback-spade git="), f"unexpected boot banner: {boot!r}"
+    assert " dirty=" in boot and " built=" in boot and boot.endswith("\r\n"), f"malformed boot banner: {boot!r}"
     ready = await recv_rbx_line_matching(dut, "READY", attempts=24)
     assert ready == "RBX READY M=C F=0\r\n", f"unexpected boot banner: {ready!r}"
 

--- a/gateware/reference/spade-projects/uart-saleae-loopback-spade/test/test_uart_saleae_loopback.py
+++ b/gateware/reference/spade-projects/uart-saleae-loopback-spade/test/test_uart_saleae_loopback.py
@@ -4,6 +4,7 @@ import cocotb
 from cocotb.triggers import Edge
 from cocotb.triggers import with_timeout
 from cocotb.utils import get_sim_time
+from boot_banner_test import assert_boot_banner
 from cocotb_helpers import start_clock
 from cocotb_helpers import tick
 
@@ -48,8 +49,7 @@ async def reset_and_capture_ready(dut):
 
     dut.rst_n.value = 1
     boot = await recv_uart_line(dut)
-    assert boot.startswith("RBXBOOT project=uart-saleae-loopback-spade git="), f"unexpected boot banner: {boot!r}"
-    assert " dirty=" in boot and " built=" in boot and boot.endswith("\r\n"), f"malformed boot banner: {boot!r}"
+    assert_boot_banner(boot, "uart-saleae-loopback-spade")
     ready = await recv_rbx_line_matching(dut, "READY", attempts=24)
     assert ready == "RBX READY M=C F=0\r\n", f"unexpected boot banner: {ready!r}"
 


### PR DESCRIPTION
## Summary
- extend build-info generation with common RBXBOOT project/git/dirty/built banner metadata
- add shared boot banner helpers and wire reset banners into UART-capable Spade projects
- update UART testbenches to consume/verify reset banners and keep UART reset idle high

## Local verification
- python3 ./tools/project.py test-with-vcd --project ./ft-uart-hex-bridge-spade
- python3 ./tools/project.py test-with-vcd --project ./pin-tester-spade
- python3 ./tools/project.py test-with-vcd --project ./sharp-pc-g850-streaming-rom-spade
- python3 ./tools/project.py test-with-vcd --project ./uart-saleae-loopback-spade
- python3 ./tools/project.py test-with-vcd --project ./sharp-organizer-card-spade
- python3 ./tools/project.py test-with-vcd --project ./sharp-pc-g850-bus-spade
- python3 ./tools/project.py test-with-vcd --project ./sharp-pc-e500-card-spade
- python3 ./tools/project.py test-with-vcd --project ./test-minimal-spade
- python3 ../spade-projects/tools/project.py test-with-vcd --project . (binary-counter)
- python3 ./scripts/test_all_components.py (shared-components)
- PATH="$HOME/.local/share/swim/bin/oss-cad-suite/bin:$PATH" swim build (ws2812b)
- uv run pytest tools/test_text_filters.py sharp-pc-e500-card-spade/tests
