### PR TITLE
[codex] Add organizer debug status commands

### DIFF
--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/src/cmd.spade
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/src/cmd.spade
@@ -1,11 +1,11 @@
 use shared_components::{ascii, serial::{FtBe, FtData}};
 
 use super::{
-    msg::{OrganizerMsg, organizer_msg_combine},
+    msg::{OrganizerMsg, organizer_msg_combine, organizer_status},
     protocol::{SaleaeModeCode, SaleaePinSource, SampleCount, SaleaeState, SyncSubMode},
 };
 
-pub(lib) type OrganizerCmdState = uint<3>;
+pub(lib) type OrganizerCmdState = uint<4>;
 
 enum OrganizerFtCmd {
     None,
@@ -23,6 +23,7 @@ pub(lib) struct OrganizerUiInputs {
     sync_sub_mode: SyncSubMode,
     saleae_mode: SaleaeModeCode,
     cmd_state: OrganizerCmdState,
+    cmd_hex_high: uint<4>,
     addr_stable_delay: SampleCount,
     data_stable_delay: SampleCount,
     pin0: SaleaePinSource,
@@ -42,6 +43,7 @@ pub(lib) struct OrganizerUiEffect {
     next_sync_sub_mode: SyncSubMode,
     next_saleae_mode: SaleaeModeCode,
     next_cmd_state: OrganizerCmdState,
+    next_cmd_hex_high: uint<4>,
     next_addr_stable_delay: SampleCount,
     next_data_stable_delay: SampleCount,
     next_pin0: SaleaePinSource,
@@ -59,6 +61,12 @@ fn cmd_wait_pin0() -> OrganizerCmdState { 3 }
 fn cmd_wait_pin1() -> OrganizerCmdState { 4 }
 fn cmd_wait_pin2() -> OrganizerCmdState { 5 }
 fn cmd_wait_pin3() -> OrganizerCmdState { 6 }
+fn cmd_wait_addr_ext_hi() -> OrganizerCmdState { 7 }
+fn cmd_wait_addr_ext_lo() -> OrganizerCmdState { 8 }
+fn cmd_wait_data_ext_hi() -> OrganizerCmdState { 9 }
+fn cmd_wait_data_ext_lo() -> OrganizerCmdState { 10 }
+fn cmd_wait_addr_ext_drop() -> OrganizerCmdState { 11 }
+fn cmd_wait_data_ext_drop() -> OrganizerCmdState { 12 }
 
 pub(lib) fn saleae_mode_standard() -> SaleaeModeCode { 0 }
 pub(lib) fn saleae_mode_memory() -> SaleaeModeCode { 1 }
@@ -68,6 +76,9 @@ pub(lib) fn pin_source_rw() -> SaleaePinSource { 2 }
 pub(lib) fn pin_source_oe() -> SaleaePinSource { 3 }
 pub(lib) fn pin_source_mskrom() -> SaleaePinSource { 6 }
 pub(lib) fn pin_source_sram1() -> SaleaePinSource { 7 }
+pub(lib) fn pin_source_addr_uart() -> SaleaePinSource { 16 }
+pub(lib) fn pin_source_data_uart() -> SaleaePinSource { 17 }
+pub(lib) fn pin_source_misc_uart() -> SaleaePinSource { 18 }
 
 fn organizer_ft_cmd_from_word(ft_ui_dout_empty: bool, word: FtData, be: FtBe) -> OrganizerFtCmd {
     let b0: uint<8> = trunc(word);
@@ -107,7 +118,8 @@ fn pin_source_valid(byte: uint<8>) -> bool {
     upper == b'L' || upper == b'H' || upper == b'R' || upper == b'O' ||
         upper == b'C' || upper == b'E' || upper == b'M' || byte == b'1' ||
         byte == b'2' || upper == b'P' || upper == b'Y' || upper == b'B' ||
-        upper == b'V' || upper == b'A' || upper == b'D'
+        upper == b'V' || upper == b'A' || upper == b'D' ||
+        upper == b'X' || upper == b'Z' || upper == b'J'
 }
 
 fn pin_source_from_byte(byte: uint<8>) -> SaleaePinSource {
@@ -140,6 +152,12 @@ fn pin_source_from_byte(byte: uint<8>) -> SaleaePinSource {
         14
     } else if upper == b'D' {
         15
+    } else if upper == b'X' {
+        pin_source_addr_uart()
+    } else if upper == b'Z' {
+        pin_source_data_uart()
+    } else if upper == b'J' {
+        pin_source_misc_uart()
     } else {
         0
     }
@@ -155,12 +173,46 @@ pub(lib) fn eval_organizer_ui(inputs: OrganizerUiInputs) -> OrganizerUiEffect {
         inputs.cmd_state == cmd_wait_pin1() ||
         inputs.cmd_state == cmd_wait_pin2() ||
         inputs.cmd_state == cmd_wait_pin3();
+    let waiting_addr_ext_hi = inputs.cmd_state == cmd_wait_addr_ext_hi();
+    let waiting_addr_ext_lo = inputs.cmd_state == cmd_wait_addr_ext_lo();
+    let waiting_data_ext_hi = inputs.cmd_state == cmd_wait_data_ext_hi();
+    let waiting_data_ext_lo = inputs.cmd_state == cmd_wait_data_ext_lo();
+    let waiting_addr_ext_drop = inputs.cmd_state == cmd_wait_addr_ext_drop();
+    let waiting_data_ext_drop = inputs.cmd_state == cmd_wait_data_ext_drop();
+    let waiting_ext_hi = waiting_addr_ext_hi || waiting_data_ext_hi;
+    let waiting_ext_lo = waiting_addr_ext_lo || waiting_data_ext_lo;
+    let waiting_ext_drop = waiting_addr_ext_drop || waiting_data_ext_drop;
+    let ext_delay: uint<8> = (zext(inputs.cmd_hex_high) << 4) | zext(decoded.value);
 
     let next_cmd_state = if !inputs.rx_valid {
         inputs.cmd_state
-    } else if inputs.cmd_state == cmd_wait_addr_delay() ||
-        inputs.cmd_state == cmd_wait_data_delay() ||
-        waiting_pin {
+    } else if inputs.cmd_state == cmd_wait_addr_delay() {
+        if inputs.rx_byte == b'=' {
+            cmd_wait_addr_ext_hi()
+        } else {
+            init_organizer_cmd_state()
+        }
+    } else if inputs.cmd_state == cmd_wait_data_delay() {
+        if inputs.rx_byte == b'=' {
+            cmd_wait_data_ext_hi()
+        } else {
+            init_organizer_cmd_state()
+        }
+    } else if waiting_addr_ext_hi {
+        if decoded.valid {
+            cmd_wait_addr_ext_lo()
+        } else {
+            cmd_wait_addr_ext_drop()
+        }
+    } else if waiting_data_ext_hi {
+        if decoded.valid {
+            cmd_wait_data_ext_lo()
+        } else {
+            cmd_wait_data_ext_drop()
+        }
+    } else if waiting_ext_drop {
+            init_organizer_cmd_state()
+    } else if waiting_ext_lo || waiting_pin {
         init_organizer_cmd_state()
     } else if inputs.rx_byte == b'a' || inputs.rx_byte == b'A' {
         cmd_wait_addr_delay()
@@ -205,7 +257,16 @@ pub(lib) fn eval_organizer_ui(inputs: OrganizerUiInputs) -> OrganizerUiEffect {
 
     let set_addr_delay = inputs.rx_valid && inputs.cmd_state == cmd_wait_addr_delay() && decoded.valid;
     let set_data_delay = inputs.rx_valid && inputs.cmd_state == cmd_wait_data_delay() && decoded.valid;
+    let set_addr_ext_delay = inputs.rx_valid && waiting_addr_ext_lo && decoded.valid;
+    let set_data_ext_delay = inputs.rx_valid && waiting_data_ext_lo && decoded.valid;
     let set_pin = inputs.rx_valid && waiting_pin && source_valid;
+    let next_cmd_hex_high = if inputs.rx_valid && waiting_ext_hi && decoded.valid {
+        decoded.value
+    } else if inputs.rx_valid && (waiting_ext_lo || waiting_ext_drop || inputs.cmd_state == cmd_wait_addr_delay() || inputs.cmd_state == cmd_wait_data_delay()) {
+        0
+    } else {
+        inputs.cmd_hex_high
+    };
 
     let usb_msg = if inputs.rx_valid && inputs.cmd_state == init_organizer_cmd_state() && inputs.rx_byte == b'c' {
         OrganizerMsg::CounterSelected()
@@ -213,6 +274,18 @@ pub(lib) fn eval_organizer_ui(inputs: OrganizerUiInputs) -> OrganizerUiEffect {
         OrganizerMsg::SyncStandardSelected()
     } else if inputs.rx_valid && inputs.cmd_state == init_organizer_cmd_state() && inputs.rx_byte == b'S' {
         OrganizerMsg::SyncMemorySelected()
+    } else if inputs.rx_valid && inputs.cmd_state == init_organizer_cmd_state() && inputs.rx_byte == b'?' {
+        OrganizerMsg::Status(organizer_status(
+            inputs.saleae_state,
+            inputs.saleae_mode,
+            inputs.addr_stable_delay,
+            inputs.data_stable_delay,
+            inputs.pin0,
+            inputs.pin1,
+            inputs.pin2,
+            inputs.pin3,
+            inputs.ft_enabled,
+        ))
     } else {
         OrganizerMsg::None()
     };
@@ -222,8 +295,9 @@ pub(lib) fn eval_organizer_ui(inputs: OrganizerUiInputs) -> OrganizerUiEffect {
         next_sync_sub_mode: next_sync_sub_mode,
         next_saleae_mode: next_saleae_mode,
         next_cmd_state: next_cmd_state,
-        next_addr_stable_delay: if set_addr_delay { zext(decoded.value) } else { inputs.addr_stable_delay },
-        next_data_stable_delay: if set_data_delay { zext(decoded.value) } else { inputs.data_stable_delay },
+        next_cmd_hex_high: next_cmd_hex_high,
+        next_addr_stable_delay: if set_addr_ext_delay { zext(ext_delay) } else if set_addr_delay { zext(decoded.value) } else { inputs.addr_stable_delay },
+        next_data_stable_delay: if set_data_ext_delay { zext(ext_delay) } else if set_data_delay { zext(decoded.value) } else { inputs.data_stable_delay },
         next_pin0: if set_pin && inputs.cmd_state == cmd_wait_pin0() { source } else { inputs.pin0 },
         next_pin1: if set_pin && inputs.cmd_state == cmd_wait_pin1() { source } else { inputs.pin1 },
         next_pin2: if set_pin && inputs.cmd_state == cmd_wait_pin2() { source } else { inputs.pin2 },

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/src/main.spade
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/src/main.spade
@@ -9,7 +9,7 @@ mod transport;
 
 use shared_components::{
     boot_banner::boot_banner_tx_gate,
-    clocking::{clk_wiz_400, sampled_bool_clock},
+    clocking::sampled_bool_clock,
     config::au_usb_uart_rx,
     ft_stream::{FtWordStreamOut, FtWordStreamState, ft_word_stream_step},
     message_stream::{TxReq8, tx_req_arbiter, tx_req_none},
@@ -55,6 +55,7 @@ use self::transport::organizer_transport;
 
 struct FtRegs {
     enabled: bool,
+    stream_fifo_full: bool,
     cur_value: OrganizerTraceWord,
     stream_state: FtWordStreamState,
 }
@@ -74,6 +75,7 @@ struct MainState {
     ft: FtRegs,
     saleae: SaleaeRegs,
     cmd_state: OrganizerCmdState,
+    cmd_hex_high: uint<4>,
     addr_stable_delay: SampleCount,
     data_stable_delay: SampleCount,
     monitor: OrganizerMonitorState,
@@ -110,6 +112,7 @@ fn reset_main_state() -> MainState {
     MainState$(
         ft: FtRegs$(
             enabled: false,
+            stream_fifo_full: false,
             cur_value: 0,
             stream_state: FtWordStreamState::GetFifo(),
         ),
@@ -124,6 +127,7 @@ fn reset_main_state() -> MainState {
             pin3: pin_source_sram1(),
         ),
         cmd_state: init_organizer_cmd_state(),
+        cmd_hex_high: 0,
         addr_stable_delay: default_stable_threshold(),
         data_stable_delay: default_stable_threshold(),
         monitor: reset_monitor_state(),
@@ -158,6 +162,7 @@ impl MainState {
                 sync_sub_mode: self.saleae.sync_sub_mode,
                 saleae_mode: self.saleae.mode,
                 cmd_state: self.cmd_state,
+                cmd_hex_high: self.cmd_hex_high,
                 addr_stable_delay: self.addr_stable_delay,
                 data_stable_delay: self.data_stable_delay,
                 pin0: self.saleae.pin0,
@@ -167,7 +172,10 @@ impl MainState {
                 ft_enabled: self.ft.enabled,
             ),
         );
-        let monitor: OrganizerMonitorOut = self.monitor.eval(
+        let monitor_transport: OrganizerMonitorTransportOut = self.monitor.drain_stream(
+            self.ft.enabled && !self.ft.stream_fifo_full,
+        );
+        let monitor: OrganizerMonitorOut = monitor_transport.next_state.eval(
             inputs.addr_sync,
             inputs.data_sync,
             inputs.misc_sync,
@@ -175,7 +183,6 @@ impl MainState {
             self.data_stable_delay,
             self.ft.enabled,
         );
-        let monitor_transport: OrganizerMonitorTransportOut = monitor.next_state.drain_stream(!inputs.stream_fifo_full);
         let ft_stream = ft_word_stream_step(
             self.ft.stream_state,
             self.ft.cur_value,
@@ -201,6 +208,7 @@ impl MainState {
             next_state: MainState$(
                 ft: FtRegs$(
                     enabled: ui.next_ft_enabled,
+                    stream_fifo_full: inputs.stream_fifo_full,
                     cur_value: ft_stream.next_cur_value,
                     stream_state: ft_stream.next_state,
                 ),
@@ -219,9 +227,10 @@ impl MainState {
                     pin3: ui.next_pin3,
                 ),
                 cmd_state: ui.next_cmd_state,
+                cmd_hex_high: ui.next_cmd_hex_high,
                 addr_stable_delay: ui.next_addr_stable_delay,
                 data_stable_delay: ui.next_data_stable_delay,
-                monitor: monitor_transport.next_state,
+                monitor: monitor.next_state,
                 msg_stream: msg_stream.state,
             ),
             tx_req: msg_stream.tx_req,
@@ -272,7 +281,7 @@ entity main_core(
     data: OrganizerData,
 ) {
     let rst = inst reset_conditioner::<4>(clk, !rst_n);
-    let clk_uart = unsafe { inst clk_wiz_400(clk) };
+    let clk_uart = clk;
     let ft_clk_clock = unsafe { inst sampled_bool_clock(ft_clk) };
 
     let conn_core_sync = inst sync_bundle::<2, 4>(clk, [conn_rw, conn_oe, conn_ci, conn_e2]);

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/src/monitor.spade
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/src/monitor.spade
@@ -27,9 +27,9 @@ use super::protocol::{
     sample_misc_value,
 };
 
-type AddrSampleState = StableSampleState<20, 32>;
-type DataSampleState = StableSampleState<8, 32>;
-type MiscSampleState = StableSampleState<11, 32>;
+type AddrSampleState = StableSampleState<20, 8>;
+type DataSampleState = StableSampleState<8, 8>;
+type MiscSampleState = StableSampleState<11, 8>;
 
 struct QueuedSample {
     valid: bool,
@@ -93,7 +93,7 @@ entity organizer_monitor_uart<#uint WIDTH>(
     sample_valid: bool,
     clk_uart: clock,
 ) -> bool {
-    let uart = inst async_uart_monitor::<WIDTH, 4, 3, 400_000_000, 100_000_000>(
+    let uart = inst async_uart_monitor::<WIDTH, 4, 3, 100_000_000, 100_000_000>(
         clk,
         rst,
         sample,
@@ -118,9 +118,9 @@ fn empty_queued_samples() -> OrganizerQueuedSamples {
 
 pub(lib) fn reset_monitor_state() -> OrganizerMonitorState {
     OrganizerMonitorState$(
-        addr: stable_sample_reset::<20, 32>(0),
-        data: stable_sample_reset::<8, 32>(0),
-        misc: stable_sample_reset::<11, 32>(0),
+        addr: stable_sample_reset::<20, 8>(0),
+        data: stable_sample_reset::<8, 8>(0),
+        misc: stable_sample_reset::<11, 8>(0),
         queued: empty_queued_samples(),
         overflow_count: 0,
     )

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/src/msg.spade
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/src/msg.spade
@@ -1,6 +1,25 @@
-use shared_components::message_stream::{ByteMsgStreamOut, ByteMsgStreamState, TxReq8, tx_req_none};
+use shared_components::{
+    ascii,
+    message_stream::{TxReq8, tx_req_none},
+};
 
-type OrganizerMsgIdx = uint<2>;
+use super::protocol::{SaleaeModeCode, SaleaePinSource, SampleCount, SaleaeState};
+
+type ByteIdx = uint<4>;
+type NameKind = uint<5>;
+type StatusPhase = uint<5>;
+
+pub(lib) struct OrganizerStatus {
+    saleae_state: SaleaeState,
+    saleae_mode: SaleaeModeCode,
+    addr_delay: SampleCount,
+    data_delay: SampleCount,
+    pin0: SaleaePinSource,
+    pin1: SaleaePinSource,
+    pin2: SaleaePinSource,
+    pin3: SaleaePinSource,
+    ft_enabled: bool,
+}
 
 pub(lib) enum OrganizerMsg {
     None,
@@ -9,6 +28,7 @@ pub(lib) enum OrganizerMsg {
     SyncMemorySelected,
     FtEnabled,
     FtDisabled,
+    Status{status: OrganizerStatus},
     CounterThenFtEnabled,
     CounterThenFtDisabled,
     SyncStandardThenFtEnabled,
@@ -17,14 +37,61 @@ pub(lib) enum OrganizerMsg {
     SyncMemoryThenFtDisabled,
 }
 
-pub type OrganizerMsgStreamState = ByteMsgStreamState<OrganizerMsg, 2>;
-pub type OrganizerMsgStreamOut = ByteMsgStreamOut<OrganizerMsg, 2>;
+pub struct OrganizerMsgStreamState {
+    cur_msg: OrganizerMsg,
+    pending_msg: OrganizerMsg,
+    status_phase: StatusPhase,
+    status_idx: ByteIdx,
+    status_ch: uint<3>,
+    simple_idx: uint<1>,
+}
+
+pub struct OrganizerMsgStreamOut {
+    state: OrganizerMsgStreamState,
+    tx_req: TxReq8,
+    msg_none: bool,
+}
+
+struct ProgressedState {
+    cur_msg: OrganizerMsg,
+    status_phase: StatusPhase,
+    status_idx: ByteIdx,
+    status_ch: uint<3>,
+    simple_idx: uint<1>,
+}
 
 pub fn init_organizer_msg_stream() -> OrganizerMsgStreamState {
-    ByteMsgStreamState$(
+    OrganizerMsgStreamState$(
         cur_msg: OrganizerMsg::None(),
-        cur_idx: 0,
         pending_msg: OrganizerMsg::None(),
+        status_phase: 0,
+        status_idx: 0,
+        status_ch: 0,
+        simple_idx: 0,
+    )
+}
+
+pub fn organizer_status(
+    saleae_state: SaleaeState,
+    saleae_mode: SaleaeModeCode,
+    addr_delay: SampleCount,
+    data_delay: SampleCount,
+    pin0: SaleaePinSource,
+    pin1: SaleaePinSource,
+    pin2: SaleaePinSource,
+    pin3: SaleaePinSource,
+    ft_enabled: bool,
+) -> OrganizerStatus {
+    OrganizerStatus$(
+        saleae_state: saleae_state,
+        saleae_mode: saleae_mode,
+        addr_delay: addr_delay,
+        data_delay: data_delay,
+        pin0: pin0,
+        pin1: pin1,
+        pin2: pin2,
+        pin3: pin3,
+        ft_enabled: ft_enabled,
     )
 }
 
@@ -44,6 +111,345 @@ pub fn organizer_msg_combine(primary: OrganizerMsg, secondary: OrganizerMsg) -> 
             (_, _) => primary,
         }
     }
+}
+
+fn tx_req_byte(byte: uint<8>) -> TxReq8 {
+    TxReq8$(valid: true, byte: byte)
+}
+
+fn indexed_bytes<#uint N>(bytes: [uint<8>; N], idx: ByteIdx) -> TxReq8 {
+    if idx < N {
+        tx_req_byte(bytes[trunc(idx)])
+    } else {
+        tx_req_none()
+    }
+}
+
+fn bool_char(value: bool) -> uint<8> {
+    if value { b'1' } else { b'0' }
+}
+
+fn byte_hex_char(value: uint<8>, high: bool) -> uint<8> {
+    if high {
+        ascii::hex_char(trunc(value >> 4))
+    } else {
+        ascii::hex_char(trunc(value))
+    }
+}
+
+fn status_delay_hex_char(delay: SampleCount, high: bool) -> uint<8> {
+    byte_hex_char(trunc(delay), high)
+}
+
+fn name_kind_addr_sample() -> NameKind { 19 }
+fn name_kind_data_sample() -> NameKind { 20 }
+fn name_kind_counter0() -> NameKind { 21 }
+
+fn phase_channel() -> StatusPhase { 17 }
+fn phase_crlf() -> StatusPhase { 18 }
+
+fn source_name_kind(source: SaleaePinSource) -> NameKind {
+    if source <= 18 {
+        source
+    } else {
+        0
+    }
+}
+
+fn name_len(kind: NameKind) -> ByteIdx {
+    if kind == 0 {
+        3
+    } else if kind == 1 {
+        4
+    } else if kind == 2 {
+        2
+    } else if kind == 3 {
+        2
+    } else if kind == 4 {
+        2
+    } else if kind == 5 {
+        2
+    } else if kind == 6 {
+        6
+    } else if kind == 7 {
+        5
+    } else if kind == 8 {
+        5
+    } else if kind == 9 {
+        5
+    } else if kind == 10 {
+        5
+    } else if kind == 11 {
+        5
+    } else if kind == 12 {
+        3
+    } else if kind == 14 {
+        8
+    } else if kind == 15 {
+        8
+    } else if kind == 16 {
+        6
+    } else if kind == 17 {
+        6
+    } else if kind == 18 {
+        6
+    } else if kind == name_kind_addr_sample() {
+        6
+    } else if kind == name_kind_data_sample() {
+        6
+    } else {
+        8
+    }
+}
+
+fn name_byte(kind: NameKind, idx: ByteIdx) -> TxReq8 {
+    if kind == 0 {
+        indexed_bytes(b"LOW", idx)
+    } else if kind == 1 {
+        indexed_bytes(b"HIGH", idx)
+    } else if kind == 2 {
+        indexed_bytes(b"RW", idx)
+    } else if kind == 3 {
+        indexed_bytes(b"OE", idx)
+    } else if kind == 4 {
+        indexed_bytes(b"CI", idx)
+    } else if kind == 5 {
+        indexed_bytes(b"E2", idx)
+    } else if kind == 6 {
+        indexed_bytes(b"MSKROM", idx)
+    } else if kind == 7 {
+        indexed_bytes(b"SRAM1", idx)
+    } else if kind == 8 {
+        indexed_bytes(b"SRAM2", idx)
+    } else if kind == 9 {
+        indexed_bytes(b"EPROM", idx)
+    } else if kind == 10 {
+        indexed_bytes(b"STNBY", idx)
+    } else if kind == 11 {
+        indexed_bytes(b"VBATT", idx)
+    } else if kind == 12 {
+        indexed_bytes(b"VPP", idx)
+    } else if kind == 14 {
+        indexed_bytes(b"ADDR_CHG", idx)
+    } else if kind == 15 {
+        indexed_bytes(b"DATA_CHG", idx)
+    } else if kind == 16 {
+        indexed_bytes(b"ADDR_U", idx)
+    } else if kind == 17 {
+        indexed_bytes(b"DATA_U", idx)
+    } else if kind == 18 {
+        indexed_bytes(b"MISC_U", idx)
+    } else if kind == name_kind_addr_sample() {
+        indexed_bytes(b"ADDR_S", idx)
+    } else if kind == name_kind_data_sample() {
+        indexed_bytes(b"DATA_S", idx)
+    } else if kind == name_kind_counter0() {
+        indexed_bytes(b"COUNTER0", idx)
+    } else if kind == name_kind_counter0() +. 1 {
+        indexed_bytes(b"COUNTER1", idx)
+    } else if kind == name_kind_counter0() +. 2 {
+        indexed_bytes(b"COUNTER2", idx)
+    } else if kind == name_kind_counter0() +. 3 {
+        indexed_bytes(b"COUNTER3", idx)
+    } else if kind == name_kind_counter0() +. 4 {
+        indexed_bytes(b"COUNTER4", idx)
+    } else if kind == name_kind_counter0() +. 5 {
+        indexed_bytes(b"COUNTER5", idx)
+    } else if kind == name_kind_counter0() +. 6 {
+        indexed_bytes(b"COUNTER6", idx)
+    } else if kind == name_kind_counter0() +. 7 {
+        indexed_bytes(b"COUNTER7", idx)
+    } else {
+        tx_req_none()
+    }
+}
+
+fn is_counter(status: OrganizerStatus) -> bool {
+    if let SaleaeState::Counter = status.saleae_state { true } else { false }
+}
+
+fn is_settling(status: OrganizerStatus) -> bool {
+    !is_counter(status) && status.saleae_mode == 2
+}
+
+fn mode_byte(status: OrganizerStatus, idx: ByteIdx) -> TxReq8 {
+    if is_counter(status) {
+        indexed_bytes(b"CTR", idx)
+    } else if status.saleae_mode == 1 {
+        indexed_bytes(b"MEM", idx)
+    } else if status.saleae_mode == 2 {
+        indexed_bytes(b"SET", idx)
+    } else {
+        indexed_bytes(b"STD", idx)
+    }
+}
+
+fn set_channel_kind(status: OrganizerStatus, ch: uint<3>) -> NameKind {
+    if ch == 0 {
+        source_name_kind(status.pin0)
+    } else if ch == 1 {
+        source_name_kind(status.pin1)
+    } else if ch == 2 {
+        source_name_kind(status.pin2)
+    } else if ch == 3 {
+        source_name_kind(status.pin3)
+    } else if ch == 4 {
+        name_kind_addr_sample()
+    } else if ch == 5 {
+        name_kind_data_sample()
+    } else if ch == 6 {
+        14
+    } else {
+        15
+    }
+}
+
+fn std_channel_kind(ch: uint<3>) -> NameKind {
+    if ch == 0 {
+        2
+    } else if ch == 1 {
+        3
+    } else if ch == 2 {
+        4
+    } else if ch == 3 {
+        5
+    } else if ch == 4 {
+        6
+    } else if ch == 5 {
+        18
+    } else if ch == 6 {
+        17
+    } else {
+        16
+    }
+}
+
+fn mem_channel_kind(ch: uint<3>) -> NameKind {
+    if ch == 0 {
+        2
+    } else if ch == 1 {
+        6
+    } else if ch == 2 {
+        7
+    } else if ch == 3 {
+        8
+    } else if ch == 4 {
+        9
+    } else if ch == 5 {
+        18
+    } else if ch == 6 {
+        17
+    } else {
+        16
+    }
+}
+
+fn channel_kind(status: OrganizerStatus, ch: uint<3>) -> NameKind {
+    if is_counter(status) {
+        name_kind_counter0() +. zext(ch)
+    } else if is_settling(status) {
+        set_channel_kind(status, ch)
+    } else if status.saleae_mode == 1 {
+        mem_channel_kind(ch)
+    } else {
+        std_channel_kind(ch)
+    }
+}
+
+fn status_pin_kind(status: OrganizerStatus, phase: StatusPhase) -> NameKind {
+    if phase == 7 {
+        source_name_kind(status.pin0)
+    } else if phase == 9 {
+        source_name_kind(status.pin1)
+    } else if phase == 11 {
+        source_name_kind(status.pin2)
+    } else {
+        source_name_kind(status.pin3)
+    }
+}
+
+fn status_phase_len(status: OrganizerStatus, phase: StatusPhase, ch: uint<3>) -> ByteIdx {
+    if phase == 0 {
+        5
+    } else if phase == 1 {
+        3
+    } else if phase == 2 {
+        3
+    } else if phase == 3 {
+        2
+    } else if phase == 4 {
+        3
+    } else if phase == 5 {
+        2
+    } else if phase == 6 || phase == 8 || phase == 10 || phase == 12 {
+        4
+    } else if phase == 7 || phase == 9 || phase == 11 || phase == 13 {
+        name_len(status_pin_kind(status, phase))
+    } else if phase == 14 {
+        4
+    } else if phase == 15 {
+        1
+    } else if phase == 16 {
+        5
+    } else if phase == phase_channel() {
+        name_len(channel_kind(status, ch)) +. if ch == 0 { 0 } else { 1 }
+    } else {
+        2
+    }
+}
+
+fn status_byte(status: OrganizerStatus, phase: StatusPhase, idx: ByteIdx, ch: uint<3>) -> TxReq8 {
+    if phase == 0 {
+        indexed_bytes(b"OS,M=", idx)
+    } else if phase == 1 {
+        mode_byte(status, idx)
+    } else if phase == 2 {
+        indexed_bytes(b",A=", idx)
+    } else if phase == 3 {
+        tx_req_byte(status_delay_hex_char(status.addr_delay, idx == 0))
+    } else if phase == 4 {
+        indexed_bytes(b",D=", idx)
+    } else if phase == 5 {
+        tx_req_byte(status_delay_hex_char(status.data_delay, idx == 0))
+    } else if phase == 6 {
+        indexed_bytes(b",P0=", idx)
+    } else if phase == 7 {
+        name_byte(source_name_kind(status.pin0), idx)
+    } else if phase == 8 {
+        indexed_bytes(b",P1=", idx)
+    } else if phase == 9 {
+        name_byte(source_name_kind(status.pin1), idx)
+    } else if phase == 10 {
+        indexed_bytes(b",P2=", idx)
+    } else if phase == 11 {
+        name_byte(source_name_kind(status.pin2), idx)
+    } else if phase == 12 {
+        indexed_bytes(b",P3=", idx)
+    } else if phase == 13 {
+        name_byte(source_name_kind(status.pin3), idx)
+    } else if phase == 14 {
+        indexed_bytes(b",FT=", idx)
+    } else if phase == 15 {
+        tx_req_byte(bool_char(status.ft_enabled))
+    } else if phase == 16 {
+        indexed_bytes(b"\r\nCH=", idx)
+    } else if phase == phase_channel() {
+        if ch != 0 && idx == 0 {
+            tx_req_byte(b',')
+        } else {
+            name_byte(channel_kind(status, ch), if ch == 0 { idx } else { idx -. 1 })
+        }
+    } else {
+        indexed_bytes(b"\r\n", idx)
+    }
+}
+
+fn status_last_byte(status: OrganizerStatus, phase: StatusPhase, idx: ByteIdx, ch: uint<3>) -> bool {
+    phase == phase_crlf() && idx == status_phase_len(status, phase, ch) -. 1
+}
+
+fn status_phase_done(status: OrganizerStatus, phase: StatusPhase, idx: ByteIdx, ch: uint<3>) -> bool {
+    idx == status_phase_len(status, phase, ch) -. 1
 }
 
 impl OrganizerMsg {
@@ -75,7 +481,7 @@ impl OrganizerMsg {
         }
     }
 
-    fn len(self) -> OrganizerMsgIdx {
+    fn simple_len(self) -> uint<2> {
         if self.first_part().is_none() {
             0
         } else if self.second_part().is_none() {
@@ -85,8 +491,13 @@ impl OrganizerMsg {
         }
     }
 
-    fn atom_byte(self) -> uint<8> {
-        match self {
+    fn simple_byte(self, idx: uint<1>) -> uint<8> {
+        let part = if idx == 0 {
+            self.first_part()
+        } else {
+            self.second_part()
+        };
+        match part {
             Self::CounterSelected => b'c',
             Self::SyncStandardSelected => b's',
             Self::SyncMemorySelected => b'S',
@@ -96,16 +507,80 @@ impl OrganizerMsg {
         }
     }
 
-    pub fn byte(self, idx: OrganizerMsgIdx) -> TxReq8 {
-        if idx >= self.len() {
-            tx_req_none()
-        } else {
-            let part = if idx == 0 {
-                self.first_part()
+    fn tx_req(self, status_phase: StatusPhase, status_idx: ByteIdx, status_ch: uint<3>, simple_idx: uint<1>) -> TxReq8 {
+        match self {
+            Self::Status$(status) => status_byte(status, status_phase, status_idx, status_ch),
+            _ => if zext(simple_idx) < self.simple_len() {
+                tx_req_byte(self.simple_byte(simple_idx))
             } else {
-                self.second_part()
-            };
-            TxReq8$(valid: true, byte: part.atom_byte())
+                tx_req_none()
+            },
+        }
+    }
+
+    fn last_byte(self, status_phase: StatusPhase, status_idx: ByteIdx, status_ch: uint<3>, simple_idx: uint<1>) -> bool {
+        match self {
+            Self::Status$(status) => status_last_byte(status, status_phase, status_idx, status_ch),
+            _ => zext(simple_idx) == self.simple_len() -. 1,
+        }
+    }
+}
+
+fn reset_progress() -> ProgressedState {
+    ProgressedState$(
+        cur_msg: OrganizerMsg::None(),
+        status_phase: 0,
+        status_idx: 0,
+        status_ch: 0,
+        simple_idx: 0,
+    )
+}
+
+fn progress_state(state: OrganizerMsgStreamState, sent: bool) -> ProgressedState {
+    if !sent {
+        ProgressedState$(
+            cur_msg: state.cur_msg,
+            status_phase: state.status_phase,
+            status_idx: state.status_idx,
+            status_ch: state.status_ch,
+            simple_idx: state.simple_idx,
+        )
+    } else if state.cur_msg.last_byte(state.status_phase, state.status_idx, state.status_ch, state.simple_idx) {
+        reset_progress()
+    } else {
+        match state.cur_msg {
+            OrganizerMsg::Status$(status) => if status_phase_done(status, state.status_phase, state.status_idx, state.status_ch) {
+                ProgressedState$(
+                    cur_msg: state.cur_msg,
+                    status_phase: if state.status_phase == phase_channel() && state.status_ch != 7 {
+                        state.status_phase
+                    } else {
+                        state.status_phase +. 1
+                    },
+                    status_idx: 0,
+                    status_ch: if state.status_phase == phase_channel() && state.status_ch != 7 {
+                        state.status_ch +. 1
+                    } else {
+                        state.status_ch
+                    },
+                    simple_idx: state.simple_idx,
+                )
+            } else {
+                ProgressedState$(
+                    cur_msg: state.cur_msg,
+                    status_phase: state.status_phase,
+                    status_idx: state.status_idx +. 1,
+                    status_ch: state.status_ch,
+                    simple_idx: state.simple_idx,
+                )
+            },
+            _ => ProgressedState$(
+                cur_msg: state.cur_msg,
+                status_phase: state.status_phase,
+                status_idx: state.status_idx,
+                status_ch: state.status_ch,
+                simple_idx: state.simple_idx +. 1,
+            ),
         }
     }
 }
@@ -116,12 +591,75 @@ pub fn organizer_msg_stream_step(
     msg_valid: bool,
     msg: OrganizerMsg,
 ) -> OrganizerMsgStreamOut {
-    state.step_with(
-        OrganizerMsg::None(),
-        fn |msg| { msg.is_none() },
-        fn |msg, idx| { msg.byte(idx) },
-        block_tx,
-        msg_valid,
-        msg,
+    let cur_none = state.cur_msg.is_none();
+    let pending_none = state.pending_msg.is_none();
+    let tx_req = if !cur_none && !block_tx {
+        state.cur_msg.tx_req(state.status_phase, state.status_idx, state.status_ch, state.simple_idx)
+    } else {
+        tx_req_none()
+    };
+    let progressed = progress_state(state, tx_req.valid);
+    let progressed_none = progressed.cur_msg.is_none();
+    let load_pending = progressed_none && !pending_none;
+    let loaded_cur_msg = if load_pending {
+        state.pending_msg
+    } else {
+        progressed.cur_msg
+    };
+    let loaded_pending_msg = if load_pending {
+        OrganizerMsg::None()
+    } else {
+        state.pending_msg
+    };
+    let loaded_none = if load_pending {
+        false
+    } else {
+        progressed_none
+    };
+    let enqueue = msg_valid && !msg.is_none();
+    let replace_current = enqueue && loaded_none;
+    let queue_pending = enqueue && !loaded_none;
+    let final_cur_msg = if replace_current {
+        msg
+    } else {
+        loaded_cur_msg
+    };
+    let final_pending_msg = if queue_pending {
+        msg
+    } else {
+        loaded_pending_msg
+    };
+    let final_none = if replace_current {
+        false
+    } else {
+        loaded_none
+    };
+    OrganizerMsgStreamOut$(
+        state: OrganizerMsgStreamState$(
+            cur_msg: final_cur_msg,
+            pending_msg: final_pending_msg,
+            status_phase: if replace_current || load_pending || progressed.cur_msg.is_none() {
+                0
+            } else {
+                progressed.status_phase
+            },
+            status_idx: if replace_current || load_pending || progressed.cur_msg.is_none() {
+                0
+            } else {
+                progressed.status_idx
+            },
+            status_ch: if replace_current || load_pending || progressed.cur_msg.is_none() {
+                0
+            } else {
+                progressed.status_ch
+            },
+            simple_idx: if replace_current || load_pending || progressed.cur_msg.is_none() {
+                0
+            } else {
+                progressed.simple_idx
+            },
+        ),
+        tx_req: tx_req,
+        msg_none: final_none,
     )
 }

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/src/protocol.spade
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/src/protocol.spade
@@ -6,7 +6,7 @@ use shared_components::{
 pub type OrganizerAddr = uint<20>;
 pub type OrganizerData = uint<8>;
 pub type MiscWord = uint<11>;
-pub type SampleCount = uint<32>;
+pub type SampleCount = uint<8>;
 pub type OrganizerTraceWord = TraceEventWord;
 pub type OrganizerOverflowCount = uint<24>;
 
@@ -20,7 +20,7 @@ pub(lib) enum SyncSubMode {
     MemoryBanks,
 }
 
-pub(lib) type SaleaePinSource = uint<4>;
+pub(lib) type SaleaePinSource = uint<5>;
 pub(lib) type SaleaeModeCode = uint<2>;
 
 pub(lib) enum OrganizerTraceKind {

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/src/render.spade
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/src/render.spade
@@ -100,6 +100,12 @@ fn selected_pin(source: SaleaePinSource, inputs: BoardRenderInputs) -> bool {
         inputs.addr_changed
     } else if source == 15 {
         inputs.data_changed
+    } else if source == 16 {
+        inputs.addr_line
+    } else if source == 17 {
+        inputs.data_line
+    } else if source == 18 {
+        inputs.misc_line
     } else {
         false
     }

--- a/gateware/reference/spade-projects/sharp-organizer-card-spade/test/test_sharp_organizer_card.py
+++ b/gateware/reference/spade-projects/sharp-organizer-card-spade/test/test_sharp_organizer_card.py
@@ -11,7 +11,7 @@ from cocotb_helpers import tick
 
 
 USB_UART_BIT_CYCLES = 100
-SALEAE_UART_BIT_CYCLES = 4
+SALEAE_UART_BIT_CYCLES = 1
 
 
 def _saleae_bit(value: int, idx: int) -> int:
@@ -96,6 +96,11 @@ async def _uart_send_byte(dut, byte: int):
 
     dut.usb_rx.value = 1
     await tick(dut.clk, USB_UART_BIT_CYCLES)
+
+
+async def _uart_send_text(dut, text: str):
+    for byte in text.encode("ascii"):
+        await _uart_send_byte(dut, byte)
 
 
 async def _uart_wait_start_fall(dut, timeout_cycles: int) -> None:
@@ -209,6 +214,14 @@ async def _uart_recv_saleae_word(dut, bit_idx: int, width: int, timeout_cycles: 
     stop = _saleae_bit(int(dut.saleae.value), bit_idx)
     assert stop == 1, f"invalid stop bit on saleae[{bit_idx}]"
     return value
+
+
+async def _wait_saleae_high(dut, bit_idx: int, timeout_cycles: int) -> None:
+    for _ in range(timeout_cycles):
+        if _saleae_bit(int(dut.saleae.value), bit_idx):
+            return
+        await tick(dut.clk, 1)
+    raise AssertionError(f"timeout waiting for saleae[{bit_idx}] to go high")
 
 
 @cocotb.test()
@@ -372,6 +385,52 @@ async def settling_delay_command_controls_addr_sample_pulse(dut):
 
 
 @cocotb.test()
+async def extended_addr_delay_command_controls_addr_sample_pulse(dut):
+    await _init(dut)
+
+    await _uart_send_text(dut, "tA=1F")
+    await tick(dut.clk, 4)
+
+    dut.addr.value = 0x22222
+
+    seen_addr_change = False
+    seen_early_addr_sample = False
+    for _ in range(24):
+        value = int(dut.saleae.value)
+        seen_addr_change |= bool(_saleae_bit(value, 6))
+        seen_early_addr_sample |= bool(_saleae_bit(value, 4))
+        await tick(dut.clk, 1)
+
+    assert seen_addr_change
+    assert not seen_early_addr_sample
+
+    await _wait_saleae_high(dut, 4, 64)
+
+
+@cocotb.test()
+async def extended_data_delay_command_controls_data_sample_pulse(dut):
+    await _init(dut)
+
+    await _uart_send_text(dut, "tD=20")
+    await tick(dut.clk, 4)
+
+    dut.data.value = 0x5A
+
+    seen_data_change = False
+    seen_early_data_sample = False
+    for _ in range(24):
+        value = int(dut.saleae.value)
+        seen_data_change |= bool(_saleae_bit(value, 7))
+        seen_early_data_sample |= bool(_saleae_bit(value, 5))
+        await tick(dut.clk, 1)
+
+    assert seen_data_change
+    assert not seen_early_data_sample
+
+    await _wait_saleae_high(dut, 5, 72)
+
+
+@cocotb.test()
 async def settling_pin_select_command_routes_unknown_pins(dut):
     await _init(dut)
 
@@ -386,6 +445,136 @@ async def settling_pin_select_command_routes_unknown_pins(dut):
     dut.conn_vpp.value = 0
     await tick(dut.clk, 4)
     assert _saleae_bit(int(dut.saleae.value), 0) == 0
+
+
+@cocotb.test()
+async def compact_commands_remain_backward_compatible(dut):
+    await _init(dut)
+
+    recv_standard = cocotb.start_soon(_uart_recv_byte(dut))
+    await _uart_send_byte(dut, ord("s"))
+    assert await recv_standard == ord("s")
+
+    recv_memory = cocotb.start_soon(_uart_recv_byte(dut))
+    await _uart_send_byte(dut, ord("S"))
+    assert await recv_memory == ord("S")
+
+    await _uart_send_text(dut, "tA5D50V1R2O3M")
+    dut.conn_vpp.value = 1
+    dut.conn_rw.value = 1
+    dut.conn_oe.value = 1
+    dut.conn_mskrom.value = 1
+    await tick(dut.clk, 4)
+    assert int(dut.saleae.value) & 0x0F == 0x0F
+
+    recv_counter = cocotb.start_soon(_uart_recv_byte(dut))
+    await _uart_send_byte(dut, ord("c"))
+    assert await recv_counter == ord("c")
+
+
+@cocotb.test()
+async def settling_mode_can_route_uart_monitor_lines(dut):
+    await _init(dut)
+
+    await _uart_send_text(dut, "t0X1Z2R3O")
+    await tick(dut.clk, 4)
+
+    dut.conn_rw.value = 1
+    dut.conn_oe.value = 0
+    dut.addr.value = 0x3A5C7
+    dut.data.value = 0xC6
+
+    seen_addr_sample = False
+    seen_data_sample = False
+    seen_addr_change = False
+    seen_data_change = False
+    addr_task = cocotb.start_soon(_uart_recv_saleae_word(dut, 0, 20))
+    data_task = cocotb.start_soon(_uart_recv_saleae_word(dut, 1, 8))
+
+    for _ in range(48):
+        value = int(dut.saleae.value)
+        seen_addr_sample |= bool(_saleae_bit(value, 4))
+        seen_data_sample |= bool(_saleae_bit(value, 5))
+        seen_addr_change |= bool(_saleae_bit(value, 6))
+        seen_data_change |= bool(_saleae_bit(value, 7))
+        await tick(dut.clk, 1)
+
+    assert seen_addr_sample
+    assert seen_data_sample
+    assert seen_addr_change
+    assert seen_data_change
+    assert await addr_task == 0x3A5C7
+    assert await data_task == 0xC6
+    assert _saleae_bit(int(dut.saleae.value), 2) == 1
+    assert _saleae_bit(int(dut.saleae.value), 3) == 0
+
+
+@cocotb.test()
+async def settling_mode_can_route_misc_uart_monitor_line(dut):
+    await _init(dut)
+
+    await _uart_send_text(dut, "t0J")
+    await tick(dut.clk, 4)
+
+    expected_misc = _misc_word(1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1)
+    misc_task = cocotb.start_soon(_uart_recv_saleae_word(dut, 0, 11))
+    dut.conn_rw.value = 1
+    dut.conn_oe.value = 0
+    dut.conn_ci.value = 1
+    dut.conn_e2.value = 0
+    dut.conn_mskrom.value = 1
+    dut.conn_sram1.value = 0
+    dut.conn_sram2.value = 1
+    dut.conn_eprom.value = 0
+    dut.conn_stnby.value = 1
+    dut.conn_vbatt.value = 0
+    dut.conn_vpp.value = 1
+
+    assert await misc_task == expected_misc
+
+
+@cocotb.test()
+async def status_command_reports_current_debug_state(dut):
+    await _init(dut)
+
+    await _uart_send_text(dut, "tA=1FD=200X1Z2R3O")
+    line1_task = cocotb.start_soon(_uart_recv_line(dut))
+    await _uart_send_byte(dut, ord("?"))
+    line1 = await line1_task
+    line2 = await _uart_recv_line(dut)
+
+    assert "M=SET" in line1
+    assert "A=1F" in line1
+    assert "D=20" in line1
+    assert "P0=ADDR_U" in line1
+    assert "P1=DATA_U" in line1
+    assert "P2=RW" in line1
+    assert "P3=OE" in line1
+    assert "FT=0" in line1
+    assert line2 == "CH=ADDR_U,DATA_U,RW,OE,ADDR_S,DATA_S,ADDR_CHG,DATA_CHG\r\n"
+
+
+@cocotb.test()
+async def invalid_extended_delay_commands_leave_delay_unchanged(dut):
+    await _init(dut)
+
+    await _uart_send_text(dut, "tA=1FA=G0D=20")
+    line1_task = cocotb.start_soon(_uart_recv_line(dut))
+    await _uart_send_byte(dut, ord("?"))
+    line1 = await line1_task
+    line2 = await _uart_recv_line(dut)
+    assert "A=1F" in line1
+    assert "D=20" in line1
+    assert "M=SET" in line1
+    assert line2.startswith("CH=")
+
+    await _uart_send_text(dut, "A=2G")
+    line1_task = cocotb.start_soon(_uart_recv_line(dut))
+    await _uart_send_byte(dut, ord("?"))
+    line1 = await line1_task
+    line2 = await _uart_recv_line(dut)
+    assert "A=1F" in line1
+    assert line2.startswith("CH=")
 
 
 @cocotb.test()


### PR DESCRIPTION
## Summary

- Add extended raw UART delay commands `A=<HH>` and `D=<HH>` while preserving legacy `A<h>` / `D<h>` parsing.
- Let settling mode route addr/data/misc UART monitor lines onto selectable Saleae pins via `X`, `Z`, and `J`.
- Add `?` status output for current Saleae/debug state, delays, selected pins, FT state, and channel mapping.
- Add cocotb coverage for extended delays, legacy compatibility, UART routing, misc routing, status query, and invalid extended command recovery.

## Validation

- `uv run python scripts/test_with_vcd.py` from `gateware/reference/spade-projects/sharp-organizer-card-spade`: `TESTS=20 PASS=20 FAIL=0`
- `uv run python scripts/build_with_spadeforge.py`: Spadeforge job `7b05789a29dcfac6b77c4456776e9c90` succeeded
- Timing report: all user-specified timing constraints met; setup worst slack `0.360ns`, hold worst slack `0.079ns`
- Bitstream flashed to FPGA flash through spadeloader job `316273de157df5729e7e3a250f0fb37d`

Bitstream path:

```text
/Users/mblsha/src/github/retrobus-explorer/gateware/reference/spade-projects/sharp-organizer-card-spade/build/forge-output-20260518-034828/7b05789a29dcfac6b77c4456776e9c90/design.bit
```

Flash command used:

```sh
curl -m 120 -v -F board=alchitry_au -F design_name=sharp-organizer-card-spade-9235a6d -F target=flash -F bitstream=@/Users/mblsha/src/github/retrobus-explorer/gateware/reference/spade-projects/sharp-organizer-card-spade/build/forge-output-20260518-034828/7b05789a29dcfac6b77c4456776e9c90/design.bit http://192.168.50.104:8080/v1/jobs
```
